### PR TITLE
Supports Views integration for (exportable) entities

### DIFF
--- a/entity_plus.module
+++ b/entity_plus.module
@@ -6,7 +6,7 @@
 
  /**
   * Define status codes used for exportable entities.
-  * 
+  *
   * Temporarily (?) wrapped in a check to see if they are already defined
   * since Entity UI declares the same.
   * See: https://github.com/backdrop-contrib/entity_plus/issues/20
@@ -17,24 +17,24 @@ if (!defined('ENTITY_CUSTOM') && !module_exists('entity_ui')) {
   * A bit flag used to let us know if an entity is in the database.
   */
   define('ENTITY_CUSTOM', 0x01);
-  
+
   /**
   * Deprecated, but still here for backward compatibility.
   */
   define('ENTITY_IN_DB', 0x01);
-  
+
   /**
   * A bit flag used to let us know if an entity is a 'default' in code.
   */
   define('ENTITY_IN_CODE', 0x02);
-  
+
   /**
   * A bit flag used to mark entities as overridden, e.g. they were originally
   * definded in code and are saved now in the database. Same as
   * (ENTITY_CUSTOM | ENTITY_IN_CODE).
   */
   define('ENTITY_OVERRIDDEN', 0x03);
-  
+
   /**
   * A bit flag used to mark entities as fixed, thus not changeable for any
   * user.
@@ -44,6 +44,7 @@ if (!defined('ENTITY_CUSTOM') && !module_exists('entity_ui')) {
 
 module_load_include('inc', 'entity_plus', 'modules/callbacks');
 module_load_include('inc', 'entity_plus', 'includes/entity_plus.property');
+module_load_include('inc', 'entity_plus', 'views/entity_plus.views');
 
 function entity_metadata_wrapper($type, $data = NULL, array $info = array()) {
   if ($type == 'entity' || (($entity_plus_info = entity_get_info()) && isset($entity_plus_info[$type]))) {
@@ -98,6 +99,20 @@ function entity_plus_autoload_info() {
     'EntityPlusControllerExportable' => 'includes/entity_plus.controller.inc',
     'EntityPlusControllerInterface' => 'includes/entity_plus.controller.inc',
     'EntityPlusControllerInterface' => 'includes/entity_plus.controller.inc',
+    'EntityPlusFieldHandlerHelper' => 'views/handlers/entity_plus_views_field_handler_helper.inc',
+    'entity_plus_views_handler_area_entity' => 'views/handlers/entity_plus_views_handler_area_entity.inc',
+    'entity_plus_views_handler_field_boolean' => 'views/handlers/entity_plus_views_handler_field_boolian.inc',
+    'entity_plus_views_handler_field_date' => 'views/handlers/entity_plus_views_handler_field_date.inc',
+    'entity_plus_views_handler_field_duration' => 'views/handlers/entity_plus_views_handler_field_duration.inc',
+    'entity_plus_views_handler_field_entity' => 'views/handlers/entity_plus_views_handler_field_entity.inc',
+    'entity_plus_views_handler_field_field' => 'views/handlers/entity_plus_views_handler_field_field.inc',
+    'entity_plus_views_handler_field_numeric' => 'views/handlers/entity_plus_views_handler_field_numeric.inc',
+    'entity_plus_views_handler_field_options' => 'views/handlers/entity_plus_views_handler_field_options.inc',
+    'entity_plus_views_handler_field_text' => 'views/handlers/entity_plus_views_handler_field_text.inc',
+    'entity_plus_views_handler_field_uri' => 'views/handlers/entity_plus_views_handler_field_uri.inc',
+    'entity_plus_views_handler_relationship_by_bundle' => 'views/handlers/entity_plus_views_handler_relationship_by_bundle.inc',
+    'entity_plus_views_handler_relationship' => 'views/handlers/entity_plus_views_handler_relationship.inc',
+    'entity_plus_views_plugin_row_entity_view' => 'views/plugins/entity_plus_views_plugin_row_entity_view.inc',
   );
 }
 

--- a/includes/entity_plus.property.inc
+++ b/includes/entity_plus.property.inc
@@ -52,7 +52,7 @@ function entity_plus_get_property_info($entity_plus_type = NULL) {
  *
  * @see hook_entity_property_info()
  */
-function entity_property_info_defaults() {
+function entity_plus_property_info_defaults() {
   return array(
     'type' => 'text',
     'getter callback' => 'entity_plus_property_verbatim_get',

--- a/views/entity_plus.views.inc
+++ b/views/entity_plus.views.inc
@@ -1,0 +1,723 @@
+<?php
+
+/**
+ * @file
+ * Provide views data for modules making use of the entity CRUD API.
+ */
+
+/**
+ * Implements hook_views_data().
+ *
+ * Provides Views integration for entities if they satisfy one of these
+ * conditions:
+ *  - hook_entity_info() specifies a 'views controller class' key.
+ *  - hook_entity_info() specifies a 'module' key, and the module does not
+ *    implement hook_views_data().
+ *
+ * @see entity_crud_hook_entity_info()
+ * @see entity_views_table_definition()
+ */
+function entity_plus_views_data() {
+  $data = array();
+
+  foreach (entity_plus_crud_get_info() as $type => $info) {
+    // Provide default integration with the basic controller class if we know
+    // the module providing the entity and it does not provide views integration.
+    if (!isset($info['views controller class'])) {
+      $info['views controller class'] = isset($info['module']) && !module_hook($info['module'], 'views_data') ? 'EntityPlusDefaultViewsController' : FALSE;
+    }
+    if ($info['views controller class']) {
+      $controller = new $info['views controller class']($type);
+      // Relationship data may return views data for already existing tables,
+      // so merge results on the second level.
+      foreach ($controller->views_data() as $table => $table_data) {
+        $data += array($table => array());
+        $data[$table] = array_merge($data[$table], $table_data);
+      }
+    }
+  }
+
+  // Add tables based upon data selection "queries" for all entity types.
+  foreach (entity_get_info() as $type => $info) {
+    $table = entity_plus_views_table_definition($type);
+    if ($table) {
+      $data['entity_' . $type] = $table;
+    }
+    // Generally expose properties marked as 'entity views field'.
+    $data['views_entity_' . $type] = array();
+    foreach (entity_plus_get_all_property_info($type) as $key => $property) {
+      if (!empty($property['entity views field'])) {
+        entity_plus_views_field_definition($key, $property, $data['views_entity_' . $type]);
+      }
+    }
+  }
+
+  // Expose generally usable entity-related fields.
+  foreach (entity_get_info() as $entity_type => $info) {
+    if (entity_plus_type_supports($entity_type, 'view')) {
+      // Expose a field allowing to display the rendered entity.
+      $data['views_entity_' . $entity_type]['rendered_entity'] = array(
+        'title' => t('Rendered @entity-type', array('@entity-type' => $info['label'])),
+        'help' => t('The @entity-type of the current relationship rendered using a view mode.', array('@entity-type' => $info['label'])),
+        'field' => array(
+          'handler' => 'entity_plus_views_handler_field_entity',
+          'type' => $entity_type,
+          // The EntityPlusFieldHandlerHelper treats the 'entity object' data
+          // selector as special case for loading the base entity.
+          'real field' => 'entity object',
+        ),
+      );
+    }
+  }
+
+  $data['entity__global']['table']['group'] = t('Entity');
+  $data['entity__global']['table']['join'] = array(
+    // #global let's it appear all the time.
+    '#global' => array(),
+  );
+  $data['entity__global']['entity'] = array(
+    'title' => t('Rendered entity'),
+    'help' => t('Displays a single chosen entity.'),
+    'area' => array(
+      'handler' => 'entity_plus_views_handler_area_entity',
+    ),
+  );
+
+  return $data;
+}
+
+/**
+ * Helper function for getting data selection based entity Views table definitions.
+ *
+ * This creates extra tables for each entity type that are not associated with a
+ * query plugin (and thus are not base tables) and just rely on the entities to
+ * retrieve the displayed data. To obtain the entities corresponding to a
+ * certain result set, the field handlers defined on the table use a generic
+ * interface defined for query plugins that are based on entity handling, and
+ * which is described in the entity_views_example_query class.
+ *
+ * These tables are called "data selection tables".
+ *
+ * Other modules providing Views integration with new query plugins that are
+ * based on entities can then use these tables as a base for their own tables
+ * (by directly using this method and modifying the returned table) and/or by
+ * specifying relationships to them. The tables returned here already specify
+ * relationships to each other wherever an entity contains a reference to
+ * another (e.g., the node author constructs a relationship from nodes to
+ * users).
+ *
+ * As filtering and other query manipulation is potentially more plugin-specific
+ * than the display, only field handlers and relationships are provided with
+ * these tables. By providing a add_selector_orderby() method, the query plugin
+ * can, however, support click-sorting for the field handlers in these tables.
+ *
+ * For a detailed discussion see http://drupal.org/node/1266036
+ *
+ * For example use see the Search API views module in the Search API project:
+ * http://drupal.org/project/search_api
+ *
+ * @param $type
+ *   The entity type whose table definition should be returned.
+ * @param $exclude
+ *   Whether properties already exposed as 'entity views field' should be
+ *   excluded. Defaults to TRUE, as they are available for all views tables for
+ *   the entity type anyways.
+ *
+ * @return
+ *   An array containing the data selection Views table definition for the
+ *   entity type.
+ *
+ * @see entity_views_field_definition()
+ */
+function entity_plus_views_table_definition($type, $exclude = TRUE) {
+  // As other modules might want to copy these tables as a base for their own
+  // Views integration, we statically cache the tables to save some time.
+  $tables = &backdrop_static(__FUNCTION__, array());
+
+  if (!isset($tables[$type])) {
+    // Work-a-round to fix updating, see http://drupal.org/node/1330874.
+    // Views data might be rebuilt on update.php before the registry is rebuilt,
+    // thus the class cannot be auto-loaded.
+    if (!class_exists('EntityPlusFieldHandlerHelper')) {
+      module_load_include('inc', 'entity_plus', 'views/handlers/entity_plus_views_field_handler_helper');
+    }
+
+    $info = entity_get_info($type);
+    $tables[$type]['table'] = array(
+      'group' => $info['label'],
+      'entity type' => $type,
+    );
+    foreach (entity_plus_get_all_property_info($type) as $key => $property) {
+      if (!$exclude || empty($property['entity views field'])) {
+        entity_plus_views_field_definition($key, $property, $tables[$type]);
+      }
+    }
+  }
+
+  return $tables[$type];
+}
+
+/**
+ * Helper function for adding a Views field definition to data selection based Views tables.
+ *
+ * @param $field
+ *   The data selector of the field to add. E.g. "title" would derive the node
+ *   title property, "body:summary" the node body's summary.
+ * @param array $property_info
+ *   The property information for which to create a field definition.
+ * @param array $table
+ *   The table into which the definition should be inserted.
+ * @param $title_prefix
+ *   Internal use only.
+ *
+ * @see entity_views_table_definition()
+ */
+function entity_plus_views_field_definition($field, array $property_info, array &$table, $title_prefix = '') {
+  $additional = array();
+  $additional_field = array();
+
+  // Create a valid Views field identifier (no colons, etc.). Keep the original
+  // data selector as real field though.
+  $key = _entity_plus_views_field_identifier($field, $table);
+  if ($key != $field) {
+    $additional['real field'] = $field;
+  }
+  $field_name = EntityPlusFieldHandlerHelper::get_selector_field_name($field);
+
+  $field_handlers = entity_plus_views_get_field_handlers();
+
+  $property_info += entity_plus_property_info_defaults();
+  $type = entity_plus_property_extract_innermost_type($property_info['type']);
+  $title = $title_prefix . $property_info['label'];
+  if ($info = entity_get_info($type)) {
+    $additional['relationship'] = array(
+      'handler' => $field_handlers['relationship'],
+      'base' => 'entity_' . $type,
+      'base field' => $info['entity keys']['id'],
+      'relationship field' => $field,
+      'label' => $title,
+    );
+    if ($property_info['type'] != $type) {
+      // This is a list of entities, so we should mark the relationship as such.
+      $additional['relationship']['multiple'] = TRUE;
+    }
+    // Implementers of the field handlers alter hook could add handlers for
+    // specific entity types.
+    if (!isset($field_handlers[$type])) {
+      $type = 'entity';
+    }
+  }
+  elseif (!empty($property_info['field'])) {
+    $type = 'field';
+    // Views' Field API field handler needs some extra definitions to work.
+    $additional_field['field_name'] = $field_name;
+    $additional_field['entity_tables'] = array();
+    $additional_field['entity type'] = $table['table']['entity type'];
+    $additional_field['is revision'] = FALSE;
+  }
+  // Copied from EntityMetadataWrapper::optionsList()
+  elseif (isset($property_info['options list']) && is_callable($property_info['options list'])) {
+    // If this is a nested property, we need to get rid of all prefixes first.
+    $type = 'options';
+    $additional_field['options callback'] = array(
+      'function' => $property_info['options list'],
+      'info' => $property_info,
+    );
+  }
+  elseif ($type == 'decimal') {
+    $additional_field['float'] = TRUE;
+  }
+
+  if (isset($field_handlers[$type])) {
+    $table += array($key => array());
+    $table[$key] += array(
+      'title' => $title,
+      'help' => empty($property_info['description']) ? t('(No information available)') : $property_info['description'],
+      'field' => array(),
+    );
+    $table[$key]['field'] += array(
+      'handler' => $field_handlers[$type],
+      'type' => $property_info['type'],
+    );
+    $table[$key] += $additional;
+    $table[$key]['field'] += $additional_field;
+  }
+  if (!empty($property_info['property info'])) {
+    foreach ($property_info['property info'] as $nested_key => $nested_property) {
+      entity_plus_views_field_definition($field . ':' . $nested_key, $nested_property, $table, $title . ' » ');
+    }
+  }
+}
+
+/**
+ * @return array
+ *   The handlers to use for the data selection based Views tables.
+ *
+ * @see hook_entity_views_field_handlers_alter()
+ */
+function entity_plus_views_get_field_handlers() {
+  $field_handlers = backdrop_static(__FUNCTION__);
+  if (!isset($field_handlers)) {
+    // Field handlers for the entity tables, by type.
+    $field_handlers = array(
+      'text'         => 'entity_plus_views_handler_field_text',
+      'token'        => 'entity_plus_views_handler_field_text',
+      'integer'      => 'entity_plus_views_handler_field_numeric',
+      'decimal'      => 'entity_plus_views_handler_field_numeric',
+      'date'         => 'entity_plus_views_handler_field_date',
+      'duration'     => 'entity_plus_views_handler_field_duration',
+      'boolean'      => 'entity_plus_views_handler_field_boolean',
+      'uri'          => 'entity_plus_views_handler_field_uri',
+      'options'      => 'entity_plus_views_handler_field_options',
+      'field'        => 'entity_plus_views_handler_field_field',
+      'entity'       => 'entity_plus_views_handler_field_entity',
+      'relationship' => 'entity_plus_views_handler_relationship',
+    );
+    backdrop_alter('entity_plus_views_field_handlers', $field_handlers);
+  }
+  return $field_handlers;
+}
+
+/**
+ * Helper function for creating valid Views field identifiers out of data selectors.
+ *
+ * Uses $table to test whether the identifier is already used, and also
+ * recognizes if a definition for the same field is already present and returns
+ * that definition's identifier.
+ *
+ * @return string
+ *   A valid Views field identifier that is not yet used as a key in $table.
+ */
+function _entity_plus_views_field_identifier($field, array $table) {
+  $key = $base = preg_replace('/[^a-zA-Z0-9]+/S', '_', $field);
+  $i = 0;
+  // The condition checks whether this sanitized field identifier is already
+  // used for another field in this table (and whether the identifier is
+  // "table", which can never be used).
+  // If $table[$key] is set, the identifier is already used, but this might be
+  // already for the same field. To test that, we need the original field name,
+  // which is either $table[$key]['real field'], if set, or $key. If this
+  // original field name is equal to $field, we can use that key. Otherwise, we
+  // append numeric suffixes until we reach an unused key.
+  while ($key == 'table' || (isset($table[$key]) && (isset($table[$key]['real field']) ? $table[$key]['real field'] : $key) != $field)) {
+    $key = $base . '_' . ++$i;
+  }
+  return $key;
+}
+
+/**
+ * Implements hook_views_plugins().
+ */
+function entity_plus_views_plugins() {
+  // Have views cache the table list for us so it gets
+  // cleared at the appropriate times.
+  $data = views_cache_get('entity_base_tables', TRUE);
+  if (!empty($data->data)) {
+    $base_tables = $data->data;
+  }
+  else {
+    $base_tables = array();
+    foreach (views_fetch_data() as $table => $data) {
+      if (!empty($data['table']['entity type']) && !empty($data['table']['base'])) {
+        $base_tables[] = $table;
+      }
+    }
+    views_cache_set('entity_base_tables', $base_tables, TRUE);
+  }
+  if (!empty($base_tables)) {
+    return array(
+      'module' => 'entity_plus',
+      'row' => array(
+        'entity' => array(
+          'title' => t('Rendered entity'),
+          'help' => t('Renders a single entity in a specific view mode (e.g. teaser).'),
+          'handler' => 'entity_plus_views_plugin_row_entity_view',
+          'uses fields' => FALSE,
+          'uses options' => TRUE,
+          'type' => 'normal',
+          'base' => $base_tables,
+        ),
+      ),
+    );
+  }
+}
+
+/**
+ * Default controller for generating basic views integration.
+ *
+ * The controller tries to generate suiting views integration for the entity
+ * based upon the schema information of its base table and the provided entity
+ * property information.
+ * For that it is possible to map a property name to its schema/views field
+ * name by adding a 'schema field' key with the name of the field as value to
+ * the property info.
+ */
+class EntityPlusDefaultViewsController {
+
+  protected $type, $info, $relationships;
+
+  public function __construct($type) {
+    $this->type = $type;
+    $this->info = entity_get_info($type);
+  }
+
+  /**
+   * Defines the result for hook_views_data().
+   */
+  public function views_data() {
+    $data = array();
+    $this->relationships = array();
+
+    if (!empty($this->info['base table'])) {
+      $table = $this->info['base table'];
+      // Define the base group of this table. Fields that don't
+      // have a group defined will go into this field by default.
+      $data[$table]['table']['group']  = backdrop_ucfirst($this->info['label']);
+      $data[$table]['table']['entity type'] = $this->type;
+
+      // If the plural label isn't available, use the regular label.
+      $label = isset($this->info['plural label']) ? $this->info['plural label'] : $this->info['label'];
+      $data[$table]['table']['base'] = array(
+        'field' => $this->info['entity keys']['id'],
+        'access query tag' => $this->type . '_access',
+        'title' => backdrop_ucfirst($label),
+        'help' => isset($this->info['description']) ? $this->info['description'] : '',
+      );
+      $data[$table]['table']['entity type'] = $this->type;
+      $data[$table] += $this->schema_fields();
+
+      // Add in any reverse-relationships which have been determined.
+      $data += $this->relationships;
+    }
+    if (!empty($this->info['revision table']) && !empty($this->info['entity keys']['revision'])) {
+      $revision_table = $this->info['revision table'];
+
+      $data[$table]['table']['default_relationship'] = array(
+        $revision_table => array(
+          'table' => $revision_table,
+          'field' => $this->info['entity keys']['revision'],
+        ),
+      );
+
+      // Define the base group of this table. Fields that don't
+      // have a group defined will go into this field by default.
+      $data[$revision_table]['table']['group']  = backdrop_ucfirst($this->info['label']) . ' ' . t('Revisions');
+      $data[$revision_table]['table']['entity type'] = $this->type;
+
+      // If the plural label isn't available, use the regular label.
+      $label = isset($this->info['plural label']) ? $this->info['plural label'] : $this->info['label'];
+      $data[$revision_table]['table']['base'] = array(
+        'field' => $this->info['entity keys']['revision'],
+        'access query tag' => $this->type . '_access',
+        'title' => backdrop_ucfirst($label) . ' ' . t('Revisions'),
+        'help' => (isset($this->info['description']) ? $this->info['description'] . ' ' : '') . t('Revisions'),
+      );
+      $data[$revision_table]['table']['entity type'] = $this->type;
+      $data[$revision_table] += $this->schema_revision_fields();
+
+      // Add in any reverse-relationships which have been determined.
+      $data += $this->relationships;
+
+      // For other base tables, explain how we join.
+      $data[$revision_table]['table']['join'] = array(
+        // Directly links to base table.
+        $table => array(
+          'left_field' => $this->info['entity keys']['revision'],
+          'field' => $this->info['entity keys']['revision'],
+        ),
+      );
+      $data[$revision_table]['table']['default_relationship'] = array(
+        $table => array(
+          'table' => $table,
+          'field' => $this->info['entity keys']['id'],
+        ),
+      );
+    }
+    return $data;
+  }
+
+  /**
+   * Try to come up with some views fields with the help of the schema and
+   * the entity property information.
+   */
+  protected function schema_fields() {
+    $schema = backdrop_get_schema($this->info['base table']);
+    $properties = entity_plus_get_property_info($this->type) + array('properties' => array());
+    $data = array();
+
+    foreach ($properties['properties'] as $name => $property_info) {
+      if (isset($property_info['schema field']) && isset($schema['fields'][$property_info['schema field']])) {
+        if ($views_info = $this->map_from_schema_info($name, $schema['fields'][$property_info['schema field']], $property_info)) {
+          $data[$name] = $views_info;
+        }
+      }
+    }
+    return $data;
+  }
+
+  /**
+   * Try to come up with some views fields with the help of the revision schema
+   * and the entity property information.
+   */
+  protected function schema_revision_fields() {
+    $data = array();
+    if (!empty($this->info['revision table'])) {
+      $schema = backdrop_get_schema($this->info['revision table']);
+      $properties = entity_plus_get_property_info($this->type) + array('properties' => array());
+
+      foreach ($properties['properties'] as $name => $property_info) {
+        if (isset($property_info['schema field']) && isset($schema['fields'][$property_info['schema field']])) {
+          if ($views_info = $this->map_from_schema_info($name, $schema['fields'][$property_info['schema field']], $property_info)) {
+            $data[$name] = $views_info;
+          }
+        }
+      }
+    }
+    return $data;
+  }
+
+  /**
+   * Comes up with views information based on the given schema and property
+   * info.
+   */
+  protected function map_from_schema_info($property_name, $schema_field_info, $property_info) {
+    $type = isset($property_info['type']) ? $property_info['type'] : 'text';
+    $views_field_name = $property_info['schema field'];
+
+    $return = array();
+
+    if (!empty($schema_field_info['serialize'])) {
+      return FALSE;
+    }
+
+    $description = array(
+      'title' => $property_info['label'],
+      'help' => isset($property_info['description']) ? $property_info['description'] : NULL,
+    );
+
+      // Add in relationships to related entities.
+    if (($info = entity_get_info($type)) && !empty($info['base table'])) {
+
+      // Prepare reversed relationship data.
+      $label_lowercase = backdrop_strtolower($this->info['label'][0]) . backdrop_substr($this->info['label'], 1);
+      $property_label_lowercase = backdrop_strtolower($property_info['label'][0]) . backdrop_substr($property_info['label'], 1);
+
+      // We name the field of the first reverse-relationship just with the
+      // base table to be backward compatible, for subsequents relationships we
+      // append the views field name in order to get a unique name.
+      $name = !isset($this->relationships[$info['base table']][$this->info['base table']]) ? $this->info['base table'] : $this->info['base table'] . '_' . $views_field_name;
+      $this->relationships[$info['base table']][$name] = array(
+        'title' => $this->info['label'],
+        'help' => t("Associated @label via the @label's @property.", array('@label' => $label_lowercase, '@property' => $property_label_lowercase)),
+        'relationship' => array(
+          'label' => $this->info['label'],
+          'handler' => $this->getRelationshipHandlerClass($this->type, $type),
+          'base' => $this->info['base table'],
+          'base field' => $views_field_name,
+          'relationship field' => isset($info['entity keys']['name']) ? $info['entity keys']['name'] : $info['entity keys']['id'],
+        ),
+      );
+
+      $return['relationship'] = array(
+        'label' => backdrop_ucfirst($info['label']),
+        'handler' => $this->getRelationshipHandlerClass($type, $this->type),
+        'base' => $info['base table'],
+        'base field' => isset($info['entity keys']['name']) ? $info['entity keys']['name'] : $info['entity keys']['id'],
+        'relationship field' => $views_field_name,
+      );
+
+      // Add in direct field/filters/sorts for the id itself too.
+      $type = isset($info['entity keys']['name']) ? 'token' : 'integer';
+      // Append the views-field-name to the title if it is different to the
+      // property name.
+      if ($property_name != $views_field_name) {
+        $description['title'] .= ' ' . $views_field_name;
+      }
+    }
+
+    switch ($type) {
+      case 'token':
+      case 'text':
+        $return += $description + array(
+          'field' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_field',
+            'click sortable' => TRUE,
+           ),
+          'sort' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_sort',
+          ),
+          'filter' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_filter_string',
+          ),
+          'argument' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_argument_string',
+          ),
+        );
+      break;
+
+      case 'decimal':
+      case 'integer':
+        $return += $description + array(
+          'field' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_field_numeric',
+            'click sortable' => TRUE,
+            'float' => ($type == 'decimal'),
+           ),
+          'sort' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_sort',
+          ),
+          'filter' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_filter_numeric',
+          ),
+          'argument' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_argument_numeric',
+          ),
+        );
+      break;
+
+      case 'date':
+        $return += $description + array(
+          'field' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_field_date',
+            'click sortable' => TRUE,
+           ),
+          'sort' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_sort_date',
+          ),
+          'filter' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_filter_date',
+          ),
+          'argument' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_argument_date',
+          ),
+        );
+      break;
+
+      case 'duration':
+        $return += $description + array(
+          'field' => array(
+            'real field' => $views_field_name,
+            'handler' => 'entity_plus_views_handler_field_duration',
+            'click sortable' => TRUE,
+           ),
+          'sort' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_sort',
+          ),
+          'filter' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_filter_numeric',
+          ),
+          'argument' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_argument_numeric',
+          ),
+        );
+      break;
+
+      case 'uri':
+        $return += $description + array(
+          'field' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_field_url',
+            'click sortable' => TRUE,
+           ),
+          'sort' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_sort',
+          ),
+          'filter' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_filter_string',
+          ),
+          'argument' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_argument_string',
+          ),
+        );
+      break;
+
+      case 'boolean':
+        $return += $description + array(
+          'field' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_field_boolean',
+            'click sortable' => TRUE,
+           ),
+          'sort' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_sort',
+          ),
+          'filter' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_filter_boolean_operator',
+          ),
+          'argument' => array(
+            'real field' => $views_field_name,
+            'handler' => 'views_handler_argument_string',
+          ),
+        );
+      break;
+    }
+
+    // If there is an options list callback, add to the filter and field.
+    if (isset($return['filter']) && !empty($property_info['options list'])) {
+      $return['filter']['handler'] = 'views_handler_filter_in_operator';
+      $return['filter']['options callback'] = array('EntityPlusDefaultViewsController', 'optionsListCallback');
+      $return['filter']['options arguments'] = array($this->type, $property_name, 'view');
+    }
+    // @todo: This class_exists is needed until views 3.2.
+    if (isset($return['field']) && !empty($property_info['options list']) && class_exists('views_handler_field_machine_name')) {
+      $return['field']['handler'] = 'views_handler_field_machine_name';
+      $return['field']['options callback'] = array('EntityPlusDefaultViewsController', 'optionsListCallback');
+      $return['field']['options arguments'] = array($this->type, $property_name, 'view');
+    }
+    return $return;
+  }
+
+  /**
+   * Determines the handler to use for a relationship to an entity type.
+   *
+   * @param $entity_type
+   *   The entity type to join to.
+   * @param $left_type
+   *   The data type from which to join.
+   */
+  function getRelationshipHandlerClass($entity_type, $left_type) {
+    // Look for an entity type which is used as bundle for the given entity
+    // type. If there is one, allow filtering the relation by bundle by using
+    // our own handler.
+    foreach (entity_get_info() as $type => $info) {
+      // In case we already join from the bundle entity we do not need to filter
+      // by bundle entity any more, so we stay with the general handler.
+      if (!empty($info['bundle of']) && $info['bundle of'] == $entity_type && $type != $left_type) {
+        return 'entity_plus_views_handler_relationship_by_bundle';
+      }
+    }
+    return 'views_handler_relationship';
+  }
+
+  /**
+   * A callback returning property options, suitable to be used as views options callback.
+   */
+  public static function optionsListCallback($type, $selector, $op = 'view') {
+    $wrapper = entity_metadata_wrapper($type, NULL);
+    $parts = explode(':', $selector);
+    foreach ($parts as $part) {
+      $wrapper = $wrapper->get($part);
+    }
+    return $wrapper->optionsList($op);
+  }
+}

--- a/views/entity_plus_views_example_query.php
+++ b/views/entity_plus_views_example_query.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * @file
+ * Contains an example for a Views query plugin that could use the data selection tables.
+ */
+
+/**
+ * Describes the additional methods looked for on a query plugin if data selection based tables or fields are used.
+ *
+ * Only get_result_entities() needs to be present, so results can be retrieved.
+ * The other methods are optional.
+ *
+ * If the table does not contain entities, however, the get_result_wrappers()
+ * method is necessary, too. If this is the case and there are no relations to
+ * entity tables, the get_result_entities() method is not needed.
+ *
+ * @see entity_views_table_definition()
+ */
+abstract class entity_plus_views_example_query extends views_plugin_query {
+
+  /**
+   * Add a sort to the query.
+   *
+   * This is used to add a sort based on an Entity API data selector instead
+   * of a field alias.
+   *
+   * This method has to be present if click-sorting on fields should be allowed
+   * for some fields using the default Entity API field handlers.
+   *
+   * @param $selector
+   *   The field to sort on, as an Entity API data selector.
+   * @param $order
+   *   The order to sort items in - either 'ASC' or 'DESC'. Defaults to 'ASC'.
+   */
+  public abstract function add_selector_orderby($selector, $order = 'ASC');
+
+  /**
+   * Returns the according entity objects for the given query results.
+   *
+   * This is compatible to the get_result_entities() method used by Views.
+   *
+   * The method is responsible for resolving the relationship and returning the
+   * entity objects for that relationship. The helper methods
+   * EntityPlusFieldHandlerHelper::construct_property_selector() and
+   * EntityPlusFieldHandlerHelper::extract_property_multiple() can be used to do
+   * this.
+   *
+   * @param $results
+   *   The results of the query, as returned by this query plugin.
+   * @param $relationship
+   *   (optional) A relationship for which the entities should be returned.
+   * @param $field
+   *   (optional) The field for which the entity should be returned. This is
+   *   only needed in case a field is derived via a referenced entity without
+   *   using a relationship. For example, if the node's field "author:name" is
+   *   used, the user entity would be returned instead of the node entity.
+   *
+   * @return
+   *   A numerically indexed array containing two items: the entity type of
+   *   entities returned by this method; and the array of entities, keyed by the
+   *   same indexes as the results.
+   *
+   * @see EntityPlusFieldHandlerHelper::extract_property_multiple()
+   */
+  public abstract function get_result_entities($results, $relationship = NULL, $field = NULL);
+
+  /**
+   * Returns the according metadata wrappers for the given query results.
+   *
+   * This can be used if no entities for the results can be given, but entity
+   * metadata wrappers can be constructed for them.
+   *
+   * @param $results
+   *   The results of the query, as returned by this query plugin.
+   * @param $relationship
+   *   (optional) A relationship for which the wrappers should be returned.
+   * @param $field
+   *   (optional) The field of which a wrapper should be returned.
+   *
+   * @return
+   *   A numerically indexed array containing two items: the data type of
+   *   the wrappers returned by this method; and the array of retrieved
+   *   EntityMetadataWrapper objects, keyed by the same indexes as the results.
+   */
+  public abstract function get_result_wrappers($results, $relationship = NULL, $field = NULL);
+
+}

--- a/views/handlers/entity_plus_views_field_handler_helper.inc
+++ b/views/handlers/entity_plus_views_field_handler_helper.inc
@@ -1,0 +1,527 @@
+<?php
+
+/**
+ * @file
+ * Contains the EntityPlusFieldHandlerHelper class.
+ */
+
+/**
+ * Helper class containing static implementations of common field handler methods.
+ *
+ * Used by the data selection entity field handlers to avoid code duplication.
+ *
+ * @see entity_views_table_definition()
+ */
+class EntityPlusFieldHandlerHelper {
+
+  /**
+   * Provide appropriate default options for a handler.
+   */
+  public static function option_definition($handler) {
+    if (isset($handler->definition['type']) && entity_plus_property_list_extract_type($handler->definition['type'])) {
+      $options['list']['contains']['mode'] = array('default' => 'collapse');
+      $options['list']['contains']['separator'] = array('default' => ', ');
+      $options['list']['contains']['type'] = array('default' => 'ul');
+    }
+    $options['link_to_entity'] = array('default' => FALSE);
+
+    return $options;
+  }
+
+  /**
+   * Provide an appropriate default option form for a handler.
+   */
+  public static function options_form($handler, &$form, &$form_state) {
+    if (isset($handler->definition['type']) && entity_plus_property_list_extract_type($handler->definition['type'])) {
+      $form['list']['mode'] = array(
+        '#type' => 'select',
+        '#title' => t('List handling'),
+        '#options' => array(
+          'collapse' => t('Concatenate values using a seperator'),
+          'list' => t('Output values as list'),
+          'first' => t('Show first (if present)'),
+          'count' => t('Show item count'),
+        ),
+        '#default_value' => $handler->options['list']['mode'],
+      );
+      $form['list']['separator'] = array(
+        '#type' => 'textfield',
+        '#title' => t('List seperator'),
+        '#default_value' => $handler->options['list']['separator'],
+        '#dependency' => array('edit-options-list-mode' => array('collapse')),
+      );
+      $form['list']['type'] = array(
+        '#type' => 'select',
+        '#title' => t('List type'),
+        '#options' => array(
+          'ul' => t('Unordered'),
+          'ol' => t('Ordered'),
+        ),
+        '#default_value' => $handler->options['list']['type'],
+        '#dependency' => array('edit-options-list-mode' => array('list')),
+      );
+    }
+    $form['link_to_entity'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Link this field to its entity'),
+      '#description' => t("When using this, you should not set any other link on the field."),
+      '#default_value' => $handler->options['link_to_entity'],
+    );
+  }
+
+  /**
+   * Add the field for the entity ID (if necessary).
+   */
+  public static function query($handler) {
+    // Copied over from views_handler_field_entity::query().
+    // Sets table_alias (entity table), base_field (entity id field) and
+    // field_alias (the field's alias).
+    $handler->table_alias = $base_table = $handler->view->base_table;
+    $handler->base_field = $handler->view->base_field;
+
+    if (!empty($handler->relationship)) {
+      foreach ($handler->view->relationship as $relationship) {
+        if ($relationship->alias == $handler->relationship) {
+          $base_table = $relationship->definition['base'];
+          $handler->table_alias = $relationship->alias;
+
+          $table_data = views_fetch_data($base_table);
+          $handler->base_field = empty($relationship->definition['base field']) ? $table_data['table']['base']['field'] : $relationship->definition['base field'];
+        }
+      }
+    }
+
+    // Add the field if the query back-end implements an add_field() method,
+    // just like the default back-end.
+    if (method_exists($handler->query, 'add_field')) {
+      $handler->field_alias = $handler->query->add_field($handler->table_alias, $handler->base_field, '');
+    }
+    else {
+      // To ensure there is an alias just set the field alias to the real field.
+      $handler->field_alias = $handler->real_field;
+    }
+  }
+
+  /**
+   * Extracts the innermost field name from a data selector.
+   *
+   * @param $selector
+   *   The data selector.
+   *
+   * @return
+   *   The last component of the data selector.
+   */
+  public static function get_selector_field_name($selector) {
+    return ltrim(substr($selector, strrpos($selector, ':')), ':');
+  }
+
+  /**
+   * Adds a click-sort to the query.
+   *
+   * @param $order
+   *   Either 'ASC' or 'DESC'.
+   */
+  public static function click_sort($handler, $order) {
+    // The normal orderby() method for this usually won't work here. So we need
+    // query plugins to provide their own method for this.
+    if (method_exists($handler->query, 'add_selector_orderby')) {
+      $selector = self::construct_property_selector($handler, TRUE);
+      $handler->query->add_selector_orderby($selector, $order);
+    }
+  }
+
+  /**
+   * Load the entities for all rows that are about to be displayed.
+   *
+   * Automatically takes care of relationships, including data selection
+   * relationships. Results are written into @code $handler->wrappers @endcode
+   * and @code $handler->entity_type @endcode is set.
+   */
+  public static function pre_render($handler, &$values, $load_always = FALSE) {
+    if (empty($values)) {
+      return;
+    }
+    if (!$load_always && empty($handler->options['link_to_entity'])) {
+      // Check whether we even need to load the entities.
+      $selector = self::construct_property_selector($handler, TRUE);
+      $load = FALSE;
+      foreach ($values as $row) {
+        if (empty($row->_entity_properties) || !array_key_exists($selector, $row->_entity_properties)) {
+          $load = TRUE;
+          break;
+        }
+      }
+      if (!$load) {
+        return;
+      }
+    }
+
+    if (method_exists($handler->query, 'get_result_wrappers')) {
+      list($handler->entity_type, $handler->wrappers) = $handler->query->get_result_wrappers($values, $handler->relationship, $handler->real_field);
+    }
+    else {
+      list($handler->entity_type, $entities) = $handler->query->get_result_entities($values, $handler->relationship, $handler->real_field);
+      $handler->wrappers = array();
+      foreach ($entities as $id => $entity) {
+        $handler->wrappers[$id] = entity_metadata_wrapper($handler->entity_type, $entity);
+      }
+    }
+  }
+
+  /**
+   * Return an Entity API data selector for the given handler's relationship.
+   *
+   * A data selector is a concatenation of properties which should be followed
+   * to arrive at a desired property that may be nested in related entities or
+   * structures. The separate properties are herein concatenated with colons.
+   *
+   * For instance, a data selector of "author:roles" would mean to first
+   * access the "author" property of the given wrapper, and then for this new
+   * wrapper to access and return the "roles" property.
+   *
+   * Lists of entities are handled automatically by always returning only the
+   * first entity.
+   *
+   * @param $handler
+   *   The handler for which to construct the selector.
+   * @param $complete
+   *   If TRUE, the complete selector for the field is returned, not just the
+   *   one for its parent. Defaults to FALSE.
+   *
+   * @return
+   *   An Entity API data selector for the given handler's relationship.
+   */
+  public static function construct_property_selector($handler, $complete = FALSE) {
+    $return = '';
+    if ($handler->relationship) {
+      $current_handler = $handler;
+      $view = $current_handler->view;
+      $relationships = array();
+      // Collect all relationships, keyed by alias.
+      foreach ($view->relationship as $key => $relationship) {
+        $key = $relationship->alias ? $relationship->alias : $key;
+        $relationships[$key] = $relationship;
+      }
+      while (!empty($current_handler->relationship) && !empty($relationships[$current_handler->relationship])) {
+        $current_handler = $relationships[$current_handler->relationship];
+        $return = $current_handler->real_field . ($return ? ":$return" : '');
+      }
+    }
+
+    if ($complete) {
+      $return .= ($return ? ':' : '') . $handler->real_field;
+    }
+    elseif ($pos = strrpos($handler->real_field, ':')) {
+      // If we have a selector as the real_field, append this to the returned
+      // relationship selector.
+      $return .= ($return ? ':' : '') . substr($handler->real_field, 0, $pos);
+    }
+
+    return $return;
+  }
+
+  /**
+   * Extracts data from several metadata wrappers based on a data selector.
+   *
+   * All metadata wrappers passed to this function have to be based on the exact
+   * same property information. The data will be returned wrapped by one or more
+   * metadata wrappers.
+   *
+   * Can be used in query plugins for the get_result_entities() and
+   * get_result_wrappers() methods.
+   *
+   * @param array $wrappers
+   *   The EntityMetadataWrapper objects from which to extract data.
+   * @param $selector
+   *   The selector specifying the data to extract.
+   *
+   * @return array
+   *   An array with numeric indices, containing the type of the extracted
+   *   wrappers in the first element. The second element of the array contains
+   *   the extracted property value(s) for each wrapper, keyed to the same key
+   *   that was used for the respecive wrapper in $wrappers. All extracted
+   *   properties are returned as metadata wrappers.
+   */
+  public static function extract_property_multiple(array $wrappers, $selector) {
+    $parts = explode(':', $selector, 2);
+    $name = $parts[0];
+
+    $results = array();
+    $entities = array();
+    $type = '';
+    foreach ($wrappers as $i => $wrapper) {
+      try {
+        $property = $wrapper->$name;
+        $type = $property->type();
+        if ($property instanceof EntityBackdropWrapper) {
+          // Remember the entity IDs to later load all at once (so as to
+          // properly utilize multiple load functionality).
+          $id = $property->getIdentifier();
+          // Only accept valid ids. $id can be FALSE for entity values that are
+          // NULL.
+          if ($id) {
+            $entities[$type][$i] = $id;
+          }
+        }
+        elseif ($property instanceof EntityStructureWrapper) {
+          $results[$i] = $property;
+        }
+        elseif ($property instanceof EntityListWrapper) {
+          foreach ($property as $item) {
+            $results[$i] = $item;
+            $type = $item->type();
+            break;
+          }
+        }
+        // Do nothing in case it cannot be applied.
+      }
+      catch (EntityMetadataWrapperException $e) {
+        // Skip single empty properties.
+      }
+    }
+
+    if ($entities) {
+      // Map back the loaded entities back to the results array.
+      foreach ($entities as $type => $id_map) {
+        $loaded = entity_load($type, $id_map);
+        foreach ($id_map as $i => $id) {
+          if (isset($loaded[$id])) {
+            $results[$i] = entity_metadata_wrapper($type, $loaded[$id]);
+          }
+        }
+      }
+    }
+
+    // If there are no further parts in the selector, we are done now.
+    if (empty($parts[1])) {
+      return array($type, $results);
+    }
+    return self::extract_property_multiple($results, $parts[1]);
+  }
+
+  /**
+   * Get the value of a certain data selector.
+   *
+   * Uses $values->_entity_properties to look for already extracted properties.
+   *
+   * @param $handler
+   *   The field handler for which to return a value.
+   * @param $values
+   *   The values for the current row retrieved from the Views query, as an
+   *   object.
+   * @param $field
+   *   The field to extract. If no value is given, the field of the given
+   *   handler is used instead. The special "entity object" value can be used to
+   *   get the base entity instead of a special field.
+   * @param $default
+   *   The value to return if the entity or field are not present.
+   */
+  public static function get_value($handler, $values, $field = NULL, $default = NULL) {
+    // There is a value cache on each handler so parent handlers rendering a
+    // single field value from a list will get the single value, not the whole
+    // list.
+    if (!isset($field) && isset($handler->current_value)) {
+      return $handler->current_value;
+    }
+    $field = isset($field) ? $field : self::get_selector_field_name($handler->real_field);
+    $selector = self::construct_property_selector($handler);
+    $selector = $selector ? "$selector:$field" : $field;
+    if (!isset($values->_entity_properties)) {
+      $values->_entity_properties = array();
+    }
+    if (!array_key_exists($selector, $values->_entity_properties)) {
+      if (!isset($handler->wrappers[$handler->view->row_index])) {
+        $values->_entity_properties[$selector] = $default;
+      }
+      elseif (is_array($handler->wrappers[$handler->view->row_index])) {
+        $values->_entity_properties[$selector] = self::extract_list_wrapper_values($handler->wrappers[$handler->view->row_index], $field);
+      }
+      else {
+        $wrapper = $handler->wrappers[$handler->view->row_index];
+        try {
+          if ($field === 'entity object') {
+            $values->_entity_properties[$selector] = $wrapper->value();
+          }
+          else {
+            $values->_entity_properties[$selector] = isset($wrapper->$field) ? $wrapper->$field->value(array('identifier' => TRUE, 'sanitize' => TRUE)) : $default;
+          }
+        }
+        catch (EntityMetadataWrapperException $e) {
+          $values->_entity_properties[$selector] = $default;
+        }
+      }
+    }
+    return $values->_entity_properties[$selector];
+  }
+
+  /**
+   * Helper method for extracting the values from an array of wrappers.
+   *
+   * Nested arrays of wrappers are also handled, the values are returned in a
+   * flat (not nested) array.
+   */
+  public static function extract_list_wrapper_values(array $wrappers, $field) {
+    $return = array();
+    foreach ($wrappers as $wrapper) {
+      if (is_array($wrapper)) {
+        $values = self::extract_list_wrapper_values($wrapper, $field);
+        if ($values) {
+          $return = array_merge($return, $values);
+        }
+      }
+      else {
+        try {
+          if ($field == 'entity object') {
+            $return[] = $wrapper->value();
+          }
+          elseif (isset($wrapper->$field)) {
+            $return[] = $wrapper->$field->value(array('identifier' => TRUE));
+          }
+        }
+        catch (EntityMetadataWrapperException $e) {
+          // An exception probably signifies a non-present property, so we just
+          // ignore it.
+        }
+      }
+    }
+    return $return;
+  }
+
+  /**
+   * Render the field.
+   *
+   * Implements the entity link functionality and list handling. Basic handling
+   * of the single values is delegated back to the field handler.
+   *
+   * @param $handler
+   *   The field handler whose field should be rendered.
+   * @param $values
+   *   The values for the current row retrieved from the Views query, as an
+   *   object.
+   *
+   * @return
+   *   The rendered value for the field.
+   */
+  public static function render($handler, $values) {
+    $value = $handler->get_value($values);
+    if (is_array($value)) {
+      return self::render_list($handler, $value, $values);
+    }
+    return self::render_entity_link($handler, $value, $values);
+  }
+
+  /**
+   * Render a list of values.
+   *
+   * @param $handler
+   *   The field handler whose field is rendered.
+   * @param $list
+   *   The list of values to render.
+   * @param $values
+   *   The values for the current row retrieved from the Views query, as an
+   *   object.
+   *
+   * @return
+   *   The rendered value for the given list.
+   */
+  public static function render_list($handler, $list, $values) {
+    // Allow easy overriding of this behaviour in the specific field handler.
+    if (method_exists($handler, 'render_list')) {
+      return $handler->render_list($list, $values);
+    }
+    $mode = isset($handler->options['list']['mode']) ? $handler->options['list']['mode'] : NULL;
+    switch ($mode) {
+      case 'first':
+        $list = count($list) ? array_shift($list) : NULL;
+        if (is_array($list)) {
+          return self::render_list($handler, $list, $values);
+        }
+        elseif (isset($list)) {
+          return self::render_entity_link($handler, $list, $values);
+        }
+        return NULL;
+
+      case 'count':
+        return count($list);
+
+      // Handles both collapse and list output. Fallback is to collapse.
+      default:
+        $inner_values = array();
+        foreach ($list as $value) {
+          $value = is_array($value) ? self::render_list($handler, $value, $values) : self::render_entity_link($handler, $value, $values);
+          if ($value) {
+            $inner_values[] = $value;
+          }
+        }
+
+        // Format output as list.
+        if ($mode == 'list') {
+          $type = isset($handler->options['list']['type']) ? $handler->options['list']['type'] : 'ul';
+          return theme('item_list', array(
+            'items' => $inner_values,
+            'type' => $type,
+          ));
+        }
+
+        $separator = isset($handler->options['list']['separator']) ? $handler->options['list']['separator'] : ', ';
+        return implode($separator, $inner_values);
+    }
+  }
+
+  /**
+   * Render a single value as a link to the entity if applicable.
+   *
+   * @param $handler
+   *   The field handler whose field is rendered.
+   * @param $value
+   *   The single value to render.
+   * @param $values
+   *   The values for the current row retrieved from the Views query, as an
+   *   object.
+   *
+   * @return
+   *   The rendered value.
+   */
+  public static function render_entity_link($handler, $value, $values) {
+    // Allow easy overriding of this behaviour in the specific field handler.
+    if (method_exists($handler, 'render_entity_link')) {
+      return $handler->render_entity_link($value, $values);
+    }
+    $render = self::render_single_value($handler, $value, $values);
+    if (!$handler->options['link_to_entity']) {
+      return $render;
+    }
+    $entity = $handler->get_value($values, 'entity object');
+    if (is_object($entity) && ($url = entity_uri($handler->entity_type, $entity))) {
+      return l($render, $url['path'], array('html' => TRUE) + $url['options']);
+    }
+    return $render;
+  }
+
+  /**
+   * Render a single value.
+   *
+   * @param $handler
+   *   The field handler whose field is rendered.
+   * @param $value
+   *   The single value to render.
+   * @param $values
+   *   The values for the current row retrieved from the Views query, as an
+   *   object.
+   *
+   * @return
+   *   The rendered value.
+   */
+  public static function render_single_value($handler, $value, $values) {
+    // Try to use the method in the specific field handler.
+    if (method_exists($handler, 'render_single_value')) {
+      $handler->current_value = $value;
+      $return = $handler->render_single_value($value, $values);
+      unset($handler->current_value);
+      return $return;
+    }
+    // Default fallback in case the field handler doesn't provide the method.
+    return is_scalar($value) ? check_plain($value) : nl2br(check_plain(print_r($value, TRUE)));
+  }
+
+}

--- a/views/handlers/entity_plus_views_handler_area_entity.inc
+++ b/views/handlers/entity_plus_views_handler_area_entity.inc
@@ -1,0 +1,150 @@
+<?php
+/**
+ * @file
+ * Renders a full entity in a views area.
+ */
+
+class entity_plus_views_handler_area_entity extends views_handler_area {
+  public function option_definition() {
+    $options = parent::option_definition();
+    $options['entity_type'] = array('default' => 'node');
+    $options['entity_id'] = array('default' => '');
+    $options['view_mode'] = array('default' => 'full');
+    $options['bypass_access'] = array('default' => FALSE);
+    return $options;
+  }
+
+  function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+
+    $entity_type_options = array();
+    foreach (entity_get_info() as $entity_type => $entity_info) {
+      $entity_type_options[$entity_type] = $entity_info['label'];
+    }
+
+    $entity_type = $this->options['entity_type'];
+
+    $form['entity_type'] = array(
+      '#type' => 'select',
+      '#title' => t('Entity type'),
+      '#options' => $entity_type_options,
+      '#description' => t('Choose the entity type you want to display in the area.'),
+      '#default_value' => $entity_type,
+      '#ajax' => array(
+        'path' => views_ui_build_form_url($form_state),
+      ),
+      '#submit' => array('views_ui_config_item_form_submit_temporary'),
+      '#executes_submit_callback' => TRUE,
+    );
+
+    $form['entity_id'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Entity id'),
+      '#description' => t('Choose the entity you want to display in the area. To render an entity given by a contextual filter use "%1" for the first argument, "%2" for the second, etc.'),
+      '#default_value' => $this->options['entity_id'],
+    );
+
+    if ($entity_type) {
+      $entity_info = entity_get_info($entity_type);
+      $options = array();
+      if (!empty($entity_info['view modes'])) {
+        foreach ($entity_info['view modes'] as $mode => $settings) {
+          $options[$mode] = $settings['label'];
+        }
+      }
+
+      if (count($options) > 1) {
+        $form['view_mode'] = array(
+          '#type' => 'select',
+          '#options' => $options,
+          '#title' => t('View mode'),
+          '#default_value' => $this->options['view_mode'],
+        );
+      }
+      else {
+        $form['view_mode_info'] = array(
+          '#type' => 'item',
+          '#title' => t('View mode'),
+          '#description' => t('Only one view mode is available for this entity type.'),
+          '#markup' => $options ? current($options) : t('Default'),
+        );
+        $form['view_mode'] = array(
+          '#type' => 'value',
+          '#value' => $options ? key($options) : 'default',
+        );
+      }
+    }
+    $form['bypass_access'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Bypass access checks'),
+      '#description' => t('If enabled, access permissions for rendering the entity are not checked.'),
+      '#default_value' => !empty($this->options['bypass_access']),
+    );
+    return $form;
+  }
+
+  public function admin_summary() {
+    $label = parent::admin_summary();
+    if (!empty($this->options['entity_id'])) {
+      return t('@label @entity_type:@entity_id', array(
+        '@label' => $label,
+        '@entity_type' => $this->options['entity_type'],
+        '@entity_id' => $this->options['entity_id'],
+      ));
+    }
+  }
+
+  public function render($empty = FALSE) {
+    if (!$empty || !empty($this->options['empty'])) {
+      return $this->render_entity($this->options['entity_type'], $this->options['entity_id'], $this->options['view_mode']);
+    }
+    return '';
+  }
+
+  /**
+   * Render an entity using the view mode.
+   */
+  public function render_entity($entity_type, $entity_id, $view_mode) {
+    $tokens = $this->get_render_tokens();
+    // Replace argument tokens in entity id.
+    $entity_id = strtr($entity_id, $tokens);
+    if (!empty($entity_type) && !empty($entity_id) && !empty($view_mode)) {
+      $entity = entity_load_single($entity_type, $entity_id);
+      if (!empty($this->options['bypass_access']) || entity_access('view', $entity_type, $entity)) {
+        $render = entity_view($entity_type, array($entity), $view_mode);
+        $render_entity = reset($render);
+        return backdrop_render($render_entity);
+      }
+    }
+    else {
+      return '';
+    }
+  }
+
+  /**
+   * Get the 'render' tokens to use for advanced rendering.
+   *
+   * This runs through all of the fields and arguments that
+   * are available and gets their values. This will then be
+   * used in one giant str_replace().
+   */
+  function get_render_tokens() {
+    $tokens = array();
+    if (!empty($this->view->build_info['substitutions'])) {
+      $tokens = $this->view->build_info['substitutions'];
+    }
+    $count = 0;
+    foreach ($this->view->display_handler->get_handlers('argument') as $arg => $handler) {
+      $token = '%' . ++$count;
+      if (!isset($tokens[$token])) {
+        $tokens[$token] = '';
+      }
+      // Use strip tags as there should never be HTML in the path.
+      // However, we need to preserve special characters like " that
+      // were removed by check_plain().
+      $tokens['%' . $count] = $handler->argument;
+    }
+
+    return $tokens;
+  }
+}

--- a/views/handlers/entity_plus_views_handler_field_boolean.inc
+++ b/views/handlers/entity_plus_views_handler_field_boolean.inc
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @file
+ * Contains the entity_views_handler_field_boolean class.
+ */
+
+/**
+ * A handler to provide proper displays for booleans.
+ *
+ * Overrides the default Views handler to retrieve the data from an entity via
+ * data selection.
+ *
+ * This handler may only be used in conjunction with data selection based Views
+ * tables or other base tables using a query plugin that supports data
+ * selection.
+ *
+ * @see entity_views_field_definition()
+ * @ingroup views_field_handlers
+ */
+class entity_plus_views_handler_field_boolean extends views_handler_field_boolean {
+
+  /**
+   * Stores the entity type of the result entities.
+   */
+  public $entity_type;
+
+  /**
+   * Stores the result entities' metadata wrappers.
+   */
+  public $wrappers = array();
+
+  /**
+   * Stores the current value when rendering list fields.
+   */
+  public $current_value;
+
+  /**
+   * Overridden to add the field for the entity ID (if necessary).
+   */
+  public function query() {
+    EntityPlusFieldHandlerHelper::query($this);
+  }
+
+  /**
+   * Adds a click-sort to the query.
+   */
+  public function click_sort($order) {
+    EntityPlusFieldHandlerHelper::click_sort($this, $order);
+  }
+
+  /**
+   * Load the entities for all rows that are about to be displayed.
+   */
+  public function pre_render(&$values) {
+    parent::pre_render($values);
+    EntityPlusFieldHandlerHelper::pre_render($this, $values);
+  }
+
+  /**
+   * Overridden to use a metadata wrapper.
+   */
+  public function get_value($values, $field = NULL) {
+    return EntityPlusFieldHandlerHelper::get_value($this, $values, $field);
+  }
+
+  /**
+   * Provide options for this handler.
+   */
+  public function option_definition() {
+    return parent::option_definition() + EntityPlusFieldHandlerHelper::option_definition($this);
+  }
+
+  /**
+   * Provide a options form for this handler.
+   */
+  public function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+    EntityPlusFieldHandlerHelper::options_form($this, $form, $form_state);
+  }
+
+  /**
+   * Render the field.
+   *
+   * @param $values
+   *   The values retrieved from the database.
+   */
+  public function render($values) {
+    return EntityPlusFieldHandlerHelper::render($this, $values);
+  }
+
+  /**
+   * Render a single field value.
+   */
+  public function render_single_value($value, $values) {
+    return parent::render($values);
+  }
+
+}

--- a/views/handlers/entity_plus_views_handler_field_date.inc
+++ b/views/handlers/entity_plus_views_handler_field_date.inc
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @file
+ * Contains the entity_views_handler_field_date class.
+ */
+
+/**
+ * A handler to provide proper displays for dates.
+ *
+ * Overrides the default Views handler to retrieve the data from an entity via
+ * data selection.
+ *
+ * This handler may only be used in conjunction with data selection based Views
+ * tables or other base tables using a query plugin that supports data
+ * selection.
+ *
+ * @see entity_views_field_definition()
+ * @ingroup views_field_handlers
+ */
+class entity_plus_views_handler_field_date extends views_handler_field_date {
+
+  /**
+   * Stores the entity type of the result entities.
+   */
+  public $entity_type;
+
+  /**
+   * Stores the result entities' metadata wrappers.
+   */
+  public $wrappers = array();
+
+  /**
+   * Stores the current value when rendering list fields.
+   */
+  public $current_value;
+
+  /**
+   * Overridden to add the field for the entity ID (if necessary).
+   */
+  public function query() {
+    EntityPlusFieldHandlerHelper::query($this);
+  }
+
+  /**
+   * Adds a click-sort to the query.
+   */
+  public function click_sort($order) {
+    EntityPlusFieldHandlerHelper::click_sort($this, $order);
+  }
+
+  /**
+   * Load the entities for all rows that are about to be displayed.
+   */
+  public function pre_render(&$values) {
+    parent::pre_render($values);
+    EntityPlusFieldHandlerHelper::pre_render($this, $values);
+  }
+
+  /**
+   * Overridden to use a metadata wrapper.
+   */
+  public function get_value($values, $field = NULL) {
+    return EntityPlusFieldHandlerHelper::get_value($this, $values, $field);
+  }
+
+  /**
+   * Provide options for this handler.
+   */
+  public function option_definition() {
+    return parent::option_definition() + EntityPlusFieldHandlerHelper::option_definition($this);
+  }
+
+  /**
+   * Provide a options form for this handler.
+   */
+  public function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+    EntityPlusFieldHandlerHelper::options_form($this, $form, $form_state);
+  }
+
+  /**
+   * Render the field.
+   *
+   * @param $values
+   *   The values retrieved from the database.
+   */
+  public function render($values) {
+    return EntityPlusFieldHandlerHelper::render($this, $values);
+  }
+
+  /**
+   * Render a single field value.
+   */
+  public function render_single_value($value, $values) {
+    return parent::render($values);
+  }
+
+}

--- a/views/handlers/entity_plus_views_handler_field_duration.inc
+++ b/views/handlers/entity_plus_views_handler_field_duration.inc
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * @file
+ * Contains the entity_views_handler_field_duration class.
+ */
+
+/**
+ * A handler to provide proper displays for duration properties retrieved via data selection.
+ *
+ * This handler may only be used in conjunction with data selection based Views
+ * tables or other base tables using a query plugin that supports data
+ * selection.
+ *
+ * @see entity_views_field_definition()
+ * @ingroup views_field_handlers
+ */
+class entity_plus_views_handler_field_duration extends views_handler_field {
+
+  /**
+   * Stores the entity type of the result entities.
+   */
+  public $entity_type;
+
+  /**
+   * Stores the result entities' metadata wrappers.
+   */
+  public $wrappers = array();
+
+  /**
+   * Stores the current value when rendering list fields.
+   */
+  public $current_value;
+
+  /**
+   * Overridden to add the field for the entity ID (if necessary).
+   */
+  public function query() {
+    EntityPlusFieldHandlerHelper::query($this);
+  }
+
+  /**
+   * Adds a click-sort to the query.
+   */
+  public function click_sort($order) {
+    EntityPlusFieldHandlerHelper::click_sort($this, $order);
+  }
+
+  /**
+   * Load the entities for all rows that are about to be displayed.
+   */
+  public function pre_render(&$values) {
+    parent::pre_render($values);
+    EntityPlusFieldHandlerHelper::pre_render($this, $values);
+  }
+
+  /**
+   * Overridden to use a metadata wrapper.
+   */
+  public function get_value($values, $field = NULL) {
+    return EntityPlusFieldHandlerHelper::get_value($this, $values, $field);
+  }
+
+  public function option_definition() {
+    $options = parent::option_definition();
+    $options += EntityPlusFieldHandlerHelper::option_definition($this);
+
+    $options['format_interval'] = array('default' => TRUE);
+    $options['granularity'] = array('default' => 2);
+    $options['prefix'] = array('default' => '', 'translatable' => TRUE);
+    $options['suffix'] = array('default' => '', 'translatable' => TRUE);
+
+    return $options;
+  }
+
+  public function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+    EntityPlusFieldHandlerHelper::options_form($this, $form, $form_state);
+
+    $form['format_interval'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Format interval'),
+      '#description' => t('If checked, the value will be formatted as a time interval. Otherwise, just the number of seconds will be displayed.'),
+      '#default_value' => $this->options['format_interval'],
+    );
+    $form['granularity'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Granularity'),
+      '#default_value' => $this->options['granularity'],
+      '#description' => t('Specify how many different units to display.'),
+      '#dependency' => array('edit-options-format-interval' => array(TRUE)),
+      '#size' => 2,
+    );
+    $form['prefix'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Prefix'),
+      '#default_value' => $this->options['prefix'],
+      '#description' => t('Text to put before the duration text.'),
+    );
+    $form['suffix'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Suffix'),
+      '#default_value' => $this->options['suffix'],
+      '#description' => t('Text to put after the duration text.'),
+    );
+  }
+
+  /**
+   * Render the field.
+   *
+   * @param $values
+   *   The values retrieved from the database.
+   */
+  public function render($values) {
+    return EntityPlusFieldHandlerHelper::render($this, $values);
+  }
+
+  /**
+   * Render a single field value.
+   */
+  public function render_single_value($value, $values) {
+    if ($this->options['format_interval']) {
+      $value = format_interval($value, (int) $this->options['granularity']);
+    }
+    // Value sanitization is handled by the wrapper, see
+    // EntityPlusFieldHandlerHelper::get_value().
+    return $this->sanitize_value($this->options['prefix'], 'xss') .
+        $value .
+        $this->sanitize_value($this->options['suffix'], 'xss');
+  }
+
+}

--- a/views/handlers/entity_plus_views_handler_field_entity.inc
+++ b/views/handlers/entity_plus_views_handler_field_entity.inc
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * @file
+ * Contains the entity_views_handler_field_entity class.
+ */
+
+/**
+ * A handler to provide proper displays for entities retrieved via data selection.
+ *
+ * This handler may only be used in conjunction with data selection based Views
+ * tables or other base tables using a query plugin that supports data
+ * selection.
+ *
+ * @see entity_views_field_definition()
+ * @ingroup views_field_handlers
+ */
+class entity_plus_views_handler_field_entity extends views_handler_field {
+
+  /**
+   * Stores the entity type of the result entities.
+   */
+  public $entity_type;
+
+  /**
+   * Stores the result entities' metadata wrappers.
+   */
+  public $wrappers = array();
+
+  /**
+   * The entity type of the entity displayed by this field.
+   */
+  public $field_entity_type;
+
+  /**
+   * Stores the current value when rendering list fields.
+   */
+  public $current_value;
+
+  /**
+   * Initialize the entity type with the field's entity type.
+   */
+  public function init(&$view, &$options) {
+    parent::init($view, $options);
+    $this->field_entity_type = entity_property_extract_innermost_type($this->definition['type']);
+  }
+
+  /**
+   * Overridden to add the field for the entity ID (if necessary).
+   */
+  public function query() {
+    EntityPlusFieldHandlerHelper::query($this);
+  }
+
+  /**
+   * Adds a click-sort to the query.
+   */
+  public function click_sort($order) {
+    EntityPlusFieldHandlerHelper::click_sort($this, $order);
+  }
+
+  /**
+   * Load the entities for all rows that are about to be displayed.
+   */
+  public function pre_render(&$values) {
+    EntityPlusFieldHandlerHelper::pre_render($this, $values);
+  }
+
+  /**
+   * Overridden to use a metadata wrapper.
+   */
+  public function get_value($values, $field = NULL) {
+    return EntityPlusFieldHandlerHelper::get_value($this, $values, $field);
+  }
+
+  public function option_definition() {
+    $options = parent::option_definition();
+    $options += EntityPlusFieldHandlerHelper::option_definition($this);
+
+    $options['display'] = array('default' => 'label');
+    $options['link_to_entity']['default'] = TRUE;
+    $options['view_mode'] = array('default' => 'default');
+    $options['bypass_access'] = array('default' => FALSE);
+
+    return $options;
+  }
+
+  public function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+    EntityPlusFieldHandlerHelper::options_form($this, $form, $form_state);
+    // We want a different form field at a different place.
+    unset($form['link_to_entity']);
+
+    $options = array(
+      'label' => t('Show entity label'),
+      'id' => t('Show entity ID'),
+      'view' => t('Show complete entity'),
+    );
+    $form['display'] = array(
+      '#type' => 'select',
+      '#title' => t('Display'),
+      '#description' => t('Decide how this field will be displayed.'),
+      '#options' => $options,
+      '#default_value' => $this->options['display'],
+    );
+    $form['link_to_entity'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Link to entity'),
+      '#description' => t('Link this field to the entity.'),
+      '#default_value' => $this->options['link_to_entity'],
+      '#dependency' => array('edit-options-display' => array('label', 'id')),
+    );
+
+    // Stolen from entity_views_plugin_row_entity_view.
+    $entity_info = entity_get_info($this->field_entity_type);
+    $options = array();
+    if (!empty($entity_info['view modes'])) {
+      foreach ($entity_info['view modes'] as $mode => $settings) {
+        $options[$mode] = $settings['label'];
+      }
+    }
+
+    if (count($options) > 1) {
+      $form['view_mode'] = array(
+        '#type' => 'select',
+        '#options' => $options,
+        '#title' => t('View mode'),
+        '#default_value' => $this->options['view_mode'],
+        '#dependency' => array('edit-options-display' => array('view')),
+      );
+    }
+    else {
+      $form['view_mode'] = array(
+        '#type' => 'value',
+        '#value' => $options ? key($options) : 'default',
+      );
+    }
+    $form['bypass_access'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Bypass access checks'),
+      '#description' => t('If enabled, access permissions for rendering the entity are not checked.'),
+      '#default_value' => !empty($this->options['bypass_access']),
+    );
+  }
+
+  public function render($values) {
+    return EntityPlusFieldHandlerHelper::render($this, $values);
+  }
+
+  /**
+   * Render a value as a link to the entity if applicable.
+   *
+   * @param $value
+   *   The value to render.
+   * @param $values
+   *   The values for the current row retrieved from the Views query, as an
+   *   object.
+   */
+  public function render_entity_link($entity, $values) {
+    $type = $this->field_entity_type;
+    if (!is_object($entity) && isset($entity) && $entity !== FALSE) {
+      $entity = entity_load_single($type, $entity);
+    }
+    if (!$entity) {
+      return '';
+    }
+    $render = $this->render_single_value($entity, $values);
+    if (!$this->options['link_to_entity'] || $this->options['display'] == 'view') {
+      return $render;
+    }
+    if (is_object($entity) && ($url = entity_uri($type, $entity))) {
+      return l($render, $url['path'], array('html' => TRUE) + $url['options']);
+    }
+    return $render;
+  }
+
+  /**
+   * Render a single field value.
+   */
+  public function render_single_value($entity, $values) {
+    $type = $this->field_entity_type;
+    if (!is_object($entity) && isset($entity) && $entity !== FALSE) {
+      $entity = entity_load_single($type, $entity);
+    }
+    // Make sure the entity exists and access is either given or bypassed.
+    if (!$entity || !(!empty($this->options['bypass_access']) || entity_access('view', $type, $entity))) {
+      return '';
+    }
+
+    if ($this->options['display'] === 'view') {
+      $entity_view = entity_view($type, array($entity), $this->options['view_mode']);
+      return render($entity_view);
+    }
+
+    if ($this->options['display'] == 'label') {
+      $value = entity_label($type, $entity);
+    }
+    // Either $options[display] == 'id', or we have no label.
+    if (empty($value)) {
+      $value = entity_id($type, $entity);
+    }
+    $value = $this->sanitize_value($value);
+
+    return $value;
+  }
+
+}

--- a/views/handlers/entity_plus_views_handler_field_field.inc
+++ b/views/handlers/entity_plus_views_handler_field_field.inc
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @file
+ * Contains the entity_views_handler_field_field class.
+ */
+
+/**
+ * A handler to provide proper displays for Field API fields.
+ *
+ * Overrides the default Views handler to retrieve the data from an entity via
+ * data selection.
+ *
+ * This handler may only be used in conjunction with data selection based Views
+ * tables or other base tables using a query plugin that supports data
+ * selection.
+ *
+ * @see entity_views_field_definition()
+ * @ingroup views_field_handlers
+ */
+class entity_plus_views_handler_field_field extends views_handler_field_field {
+
+  /**
+   * Stores the entity type of the result entities.
+   */
+  public $entity_type;
+
+  /**
+   * Stores the result entities' metadata wrappers.
+   */
+  public $wrappers = array();
+
+  /**
+   * The entity for which this field is currently rendered.
+   */
+  public $entity;
+
+  /**
+   * Return TRUE if the user has access to view this field.
+   */
+  public function access() {
+    return field_access('view', $this->field_info, $this->definition['entity type']);
+  }
+
+  /**
+   * Overridden to add the field for the entity ID (if necessary).
+   */
+  public function query($use_groupby = FALSE) {
+    EntityPlusFieldHandlerHelper::query($this);
+  }
+
+  /**
+   * Adds a click-sort to the query.
+   */
+  public function click_sort($order) {
+    EntityPlusFieldHandlerHelper::click_sort($this, $order);
+  }
+
+  /**
+   * Override so it doesn't do any harm (or, anything at all).
+   */
+  public function post_execute(&$values) { }
+
+  /**
+   * Load the entities for all rows that are about to be displayed.
+   */
+  public function pre_render(&$values) {
+    parent::pre_render($values);
+    EntityPlusFieldHandlerHelper::pre_render($this, $values, TRUE);
+  }
+
+  /**
+   * Overridden to get the items our way.
+   */
+  public function get_items($values) {
+    $items = array();
+    // Set the entity type for the parent handler.
+    $values->_field_data[$this->field_alias]['entity_type'] = $this->entity_type;
+    // We need special handling for lists of entities as the base.
+    $entities = EntityPlusFieldHandlerHelper::get_value($this, $values, 'entity object');
+    if (!is_array($entities)) {
+      $entities = $entities ? array($entities) : array();
+    }
+    foreach ($entities as $entity) {
+      // Only try to render the field if it is even present on this bundle.
+      // Otherwise, field_view_field() will trigger a fatal.
+      list (, , $bundle) = entity_extract_ids($this->entity_type, $entity);
+      if (field_info_instance($this->entity_type, $this->definition['field_name'], $bundle)) {
+        // Set the currently rendered entity.
+        $values->_field_data[$this->field_alias]['entity'] = $entity;
+        $items = array_merge($items, $this->set_items($values, $this->view->row_index));
+      }
+    }
+    return $items;
+  }
+
+  /**
+   * Overridden to force displaying multiple values in a single row.
+   */
+  function multiple_options_form(&$form, &$form_state) {
+    parent::multiple_options_form($form, $form_state);
+    $form['group_rows']['#default_value'] = TRUE;
+    $form['group_rows']['#disabled'] = TRUE;
+  }
+}

--- a/views/handlers/entity_plus_views_handler_field_numeric.inc
+++ b/views/handlers/entity_plus_views_handler_field_numeric.inc
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @file
+ * Contains the entity_views_handler_field_numeric class.
+ */
+
+/**
+ * Render a field as a numeric value.
+ *
+ * Overrides the default Views handler to retrieve the data from an entity via
+ * data selection.
+ *
+ * This handler may only be used in conjunction with data selection based Views
+ * tables or other base tables using a query plugin that supports data
+ * selection.
+ *
+ * @see entity_views_field_definition()
+ * @ingroup views_field_handlers
+ */
+class entity_plus_views_handler_field_numeric extends views_handler_field_numeric {
+
+  /**
+   * Stores the entity type of the result entities.
+   */
+  public $entity_type;
+
+  /**
+   * Stores the result entities' metadata wrappers.
+   */
+  public $wrappers = array();
+
+  /**
+   * Stores the current value when rendering list fields.
+   */
+  public $current_value;
+
+  /**
+   * Overridden to add the field for the entity ID (if necessary).
+   */
+  public function query() {
+    EntityPlusFieldHandlerHelper::query($this);
+  }
+
+  /**
+   * Adds a click-sort to the query.
+   */
+  public function click_sort($order) {
+    EntityPlusFieldHandlerHelper::click_sort($this, $order);
+  }
+
+  /**
+   * Load the entities for all rows that are about to be displayed.
+   */
+  public function pre_render(&$values) {
+    parent::pre_render($values);
+    EntityPlusFieldHandlerHelper::pre_render($this, $values);
+  }
+
+  /**
+   * Overridden to use a metadata wrapper.
+   */
+  public function get_value($values, $field = NULL) {
+    return EntityPlusFieldHandlerHelper::get_value($this, $values, $field);
+  }
+
+  /**
+   * Provide options for this handler.
+   */
+  public function option_definition() {
+    return parent::option_definition() + EntityPlusFieldHandlerHelper::option_definition($this);
+  }
+
+  /**
+   * Provide a options form for this handler.
+   */
+  public function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+    EntityPlusFieldHandlerHelper::options_form($this, $form, $form_state);
+  }
+
+  /**
+   * Render the field.
+   *
+   * @param $values
+   *   The values retrieved from the database.
+   */
+  public function render($values) {
+    return EntityPlusFieldHandlerHelper::render($this, $values);
+  }
+
+  /**
+   * Render a single field value.
+   */
+  public function render_single_value($value, $values) {
+    return parent::render($values);
+  }
+
+}

--- a/views/handlers/entity_plus_views_handler_field_options.inc
+++ b/views/handlers/entity_plus_views_handler_field_options.inc
@@ -1,0 +1,120 @@
+<?php
+
+/**
+ * @file
+ * Contains the entity_views_handler_field_options class.
+ */
+
+/**
+ * A handler to provide proper displays for values chosen from a set of options.
+ *
+ * This handler may only be used in conjunction with data selection based Views
+ * tables or other base tables using a query plugin that supports data
+ * selection.
+ *
+ * @see entity_views_field_definition()
+ * @ingroup views_field_handlers
+ */
+class entity_plus_views_handler_field_options extends views_handler_field {
+
+  /**
+   * Stores the entity type of the result entities.
+   */
+  public $entity_type;
+
+  /**
+   * Stores the result entities' metadata wrappers.
+   */
+  public $wrappers = array();
+
+  /**
+   * Stores the current value when rendering list fields.
+   */
+  public $current_value;
+
+  /**
+   * The key / name mapping for the options.
+   */
+  public $option_list;
+
+  /**
+   * Overridden to add the field for the entity ID (if necessary).
+   */
+  public function query() {
+    EntityPlusFieldHandlerHelper::query($this);
+  }
+
+  /**
+   * Adds a click-sort to the query.
+   */
+  public function click_sort($order) {
+    EntityPlusFieldHandlerHelper::click_sort($this, $order);
+  }
+
+  /**
+   * Load the entities for all rows that are about to be displayed.
+   */
+  public function pre_render(&$values) {
+    parent::pre_render($values);
+    EntityPlusFieldHandlerHelper::pre_render($this, $values);
+  }
+
+  /**
+   * Overridden to use a metadata wrapper.
+   */
+  public function get_value($values, $field = NULL) {
+    return EntityPlusFieldHandlerHelper::get_value($this, $values, $field);
+  }
+
+  /**
+   * Specifies the options this handler uses.
+   */
+  public function option_definition() {
+    $options = parent::option_definition();
+    $options += EntityPlusFieldHandlerHelper::option_definition($this);
+    $options['format_name'] = array('default' => TRUE);
+    return $options;
+  }
+
+  /**
+   * Returns an option form for setting this handler's options.
+   */
+  public function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+    EntityPlusFieldHandlerHelper::options_form($this, $form, $form_state);
+
+    $form['format_name'] = array(
+      '#title' => t('Use human-readable name'),
+      '#type' => 'checkbox',
+      '#description' => t("If this is checked, the values' names will be displayed instead of their internal identifiers."),
+      '#default_value' => $this->options['format_name'],
+      '#weight' => -5,
+    );
+  }
+
+  public function render($values) {
+    return EntityPlusFieldHandlerHelper::render($this, $values);
+  }
+
+  /**
+   * Render a single field value.
+   */
+  public function render_single_value($value, $values) {
+    if (!isset($this->option_list)) {
+      $this->option_list = array();
+      $callback = $this->definition['options callback'];
+      if (is_callable($callback['function'])) {
+        // If a selector is used, get the name of the selected field.
+        $field_name = EntityPlusFieldHandlerHelper::get_selector_field_name($this->real_field);
+        $this->option_list = call_user_func($callback['function'], $field_name, $callback['info'], 'view');
+      }
+    }
+    if ($this->options['format_name'] && isset($this->option_list[$value])) {
+      $value = $this->option_list[$value];
+    }
+    // Sanitization is handled by the wrapper, see
+    // EntityPlusFieldHandlerHelper::get_value().
+    return $value;
+  }
+
+}

--- a/views/handlers/entity_plus_views_handler_field_text.inc
+++ b/views/handlers/entity_plus_views_handler_field_text.inc
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * @file
+ * Contains the entity_views_handler_field_text class.
+ */
+
+/**
+ * A handler to display text data.
+ *
+ * Overrides the default Views handler to retrieve the data from an entity via
+ * data selection.
+ *
+ * This handler may only be used in conjunction with data selection based Views
+ * tables or other base tables using a query plugin that supports data
+ * selection.
+ *
+ * @see entity_views_field_definition()
+ * @ingroup views_field_handlers
+ */
+class entity_plus_views_handler_field_text extends views_handler_field {
+
+  /**
+   * Stores the entity type of the result entities.
+   */
+  public $entity_type;
+
+  /**
+   * Stores the result entities' metadata wrappers.
+   */
+  public $wrappers = array();
+
+  /**
+   * Stores the current value when rendering list fields.
+   */
+  public $current_value;
+
+  /**
+   * Overridden to add the field for the entity ID (if necessary).
+   */
+  public function query() {
+    EntityPlusFieldHandlerHelper::query($this);
+  }
+
+  /**
+   * Adds a click-sort to the query.
+   */
+  public function click_sort($order) {
+    EntityPlusFieldHandlerHelper::click_sort($this, $order);
+  }
+
+  /**
+   * Load the entities for all rows that are about to be displayed.
+   */
+  public function pre_render(&$values) {
+    parent::pre_render($values);
+    EntityPlusFieldHandlerHelper::pre_render($this, $values);
+  }
+
+  /**
+   * Overridden to use a metadata wrapper.
+   */
+  public function get_value($values, $field = NULL) {
+    return EntityPlusFieldHandlerHelper::get_value($this, $values, $field);
+  }
+
+  /**
+   * Provide options for this handler.
+   */
+  public function option_definition() {
+    return parent::option_definition() + EntityPlusFieldHandlerHelper::option_definition($this);
+  }
+
+  /**
+   * Provide a options form for this handler.
+   */
+  public function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+    EntityPlusFieldHandlerHelper::options_form($this, $form, $form_state);
+  }
+
+  /**
+   * Render the field.
+   *
+   * @param $values
+   *   The values retrieved from the database.
+   */
+  public function render($values) {
+    return EntityPlusFieldHandlerHelper::render($this, $values);
+  }
+
+  /**
+   * Render a single field value.
+   */
+  public function render_single_value($value, $values) {
+    // Sanitization is handled by the wrapper, see
+    // EntityPlusFieldHandlerHelper::get_value().
+    return $value;
+  }
+
+}

--- a/views/handlers/entity_plus_views_handler_field_uri.inc
+++ b/views/handlers/entity_plus_views_handler_field_uri.inc
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @file
+ * Contains the entity_views_handler_field_uri class.
+ */
+
+/**
+ * Field handler to provide simple renderer that turns a URL into a clickable link.
+ *
+ * Overrides the default Views handler to retrieve the data from an entity via
+ * data selection.
+ *
+ * This handler may only be used in conjunction with data selection based Views
+ * tables or other base tables using a query plugin that supports data
+ * selection.
+ *
+ * @see entity_views_field_definition()
+ * @ingroup views_field_handlers
+ */
+class entity_plus_views_handler_field_uri extends views_handler_field_url {
+
+  /**
+   * Stores the entity type of the result entities.
+   */
+  public $entity_type;
+
+  /**
+   * Stores the result entities' metadata wrappers.
+   */
+  public $wrappers = array();
+
+  /**
+   * Stores the current value when rendering list fields.
+   */
+  public $current_value;
+
+  /**
+   * Overridden to add the field for the entity ID (if necessary).
+   */
+  public function query() {
+    EntityPlusFieldHandlerHelper::query($this);
+  }
+
+  /**
+   * Adds a click-sort to the query.
+   */
+  public function click_sort($order) {
+    EntityPlusFieldHandlerHelper::click_sort($this, $order);
+  }
+
+  /**
+   * Load the entities for all rows that are about to be displayed.
+   */
+  public function pre_render(&$values) {
+    parent::pre_render($values);
+    EntityPlusFieldHandlerHelper::pre_render($this, $values);
+  }
+
+  /**
+   * Overridden to use a metadata wrapper.
+   */
+  public function get_value($values, $field = NULL) {
+    return EntityPlusFieldHandlerHelper::get_value($this, $values, $field);
+  }
+
+  /**
+   * Provide options for this handler.
+   */
+  public function option_definition() {
+    return parent::option_definition() + EntityPlusFieldHandlerHelper::option_definition($this);
+  }
+
+  /**
+   * Provide a options form for this handler.
+   */
+  public function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+    EntityPlusFieldHandlerHelper::options_form($this, $form, $form_state);
+  }
+
+  /**
+   * Render the field.
+   *
+   * @param $values
+   *   The values retrieved from the database.
+   */
+  public function render($values) {
+    return EntityPlusFieldHandlerHelper::render($this, $values);
+  }
+
+  /**
+   * Render a single field value.
+   */
+  public function render_single_value($value, $values) {
+    return parent::render($values);
+  }
+
+}

--- a/views/handlers/entity_plus_views_handler_relationship.inc
+++ b/views/handlers/entity_plus_views_handler_relationship.inc
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @file
+ * Contains the entity_views_handler_relationship class.
+ */
+
+/**
+ * Relationship handler for data selection tables.
+ *
+ * This handler may only be used in conjunction with data selection based Views
+ * tables or other base tables using a query plugin that supports data
+ * selection.
+ *
+ * @see entity_views_field_definition()
+ * @ingroup views_field_handlers
+ */
+class entity_plus_views_handler_relationship extends views_handler_relationship {
+
+  /**
+   * Slightly modify the options form provided by the parent handler.
+   */
+  public function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+    // This won't work with data selector-based relationships, as we only
+    // inspect those *after* the results are known.
+    $form['required']['#access'] = FALSE;
+    // Notify the user of our restrictions regarding lists of entities, if
+    // appropriate.
+    if (!empty($this->definition['multiple'])) {
+      $form['multiple_note'] = array(
+        '#markup' => t('<strong>Note:</strong> This is a multi-valued relationship, which is currently not supported. ' .
+            'Only the first related entity will be shown.'),
+        '#weight' => -5,
+      );
+    }
+  }
+
+  /**
+   * Called to implement a relationship in a query.
+   *
+   * As we don't add any data to the query itself, we don't have to do anything
+   * here. Views just don't thinks we have been called unless we set our
+   * $alias property. Otherwise, this override is just here to keep PHP from
+   * blowing up by calling inexistent methods on the query plugin.
+   */
+  public function query() {
+    $this->alias = $this->options['id'];
+  }
+
+}

--- a/views/handlers/entity_plus_views_handler_relationship_by_bundle.inc
+++ b/views/handlers/entity_plus_views_handler_relationship_by_bundle.inc
@@ -1,0 +1,117 @@
+<?php
+/**
+ * @file
+ * Contains the entity_views_handler_relationship_by_bundle class.
+ */
+
+/**
+ * Relationship handler for entity relationships that may limit the join to one or more bundles.
+ *
+ * This handler is only applicable for entities that are using bundle entities,
+ * i.e. entities having the 'bundle of' entity info key set.
+ *
+ * For example, this allows a relationship from users to profiles of a certain
+ * profile type.
+ *
+ * @see entity_crud_hook_entity_info()
+ * @ingroup views_field_handlers
+ */
+class entity_plus_views_handler_relationship_by_bundle extends views_handler_relationship {
+  function option_definition() {
+    $options = parent::option_definition();
+    $options['bundle_types'] = array('default' => array());
+
+    return $options;
+  }
+
+  /**
+   * Add an entity type option.
+   */
+  function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+
+    // Get the entity type and info from the table data for the base on the
+    // right hand side of the relationship join.
+    $table_data = views_fetch_data($this->definition['base']);
+    $entity_type = $table_data['table']['entity type'];
+    $entity_info = entity_get_info($entity_type);
+
+    // Get the info of the bundle entity.
+    foreach (entity_get_info() as $type => $info) {
+      if (isset($info['bundle of']) && $info['bundle of'] == $entity_type) {
+        $entity_bundle_info = $info;
+        break;
+      }
+    }
+
+    $plural_label = isset($entity_bundle_info['plural label']) ? $entity_bundle_info['plural label'] : $entity_bundle_info['label'] . 's';
+    $bundle_options = array();
+    foreach ($entity_info['bundles'] as $name => $info) {
+      $bundle_options[$name] = $info['label'];
+    }
+
+    $form['bundle_types'] = array(
+      '#title' => $plural_label,
+      '#type' => 'checkboxes',
+      '#description' => t('Restrict this relationship to one or more @bundles.', array('@bundles' => strtolower($entity_bundle_info['plural label']))),
+      '#options' => $bundle_options,
+      '#default_value' => $this->options['bundle_types'],
+    );
+  }
+
+  /**
+   * Make sure only checked bundle types are left.
+   */
+  function options_submit(&$form, &$form_state) {
+    $form_state['values']['options']['bundle_types'] = array_filter($form_state['values']['options']['bundle_types']);
+    parent::options_submit($form, $form_state);
+  }
+
+  /**
+   * Called to implement a relationship in a query.
+   *
+   * Mostly the same as the parent method, except we add an extra clause to
+   * the join.
+   */
+  function query() {
+    $table_data = views_fetch_data($this->definition['base']);
+    $base_field = empty($this->definition['base field']) ? $table_data['table']['base']['field'] : $this->definition['base field'];
+    $this->ensure_my_table();
+
+    $def = $this->definition;
+    $def['table'] = $this->definition['base'];
+    $def['field'] = $base_field;
+    $def['left_table'] = $this->table_alias;
+    $def['left_field'] = $this->field;
+    if (!empty($this->options['required'])) {
+      $def['type'] = 'INNER';
+    }
+
+    // Add an extra clause to the join if there are bundle types selected.
+    if ($this->options['bundle_types']) {
+      $entity_info = entity_get_info($table_data['table']['entity type']);
+      $def['extra'] = array(
+        array(
+          // The table and the IN operator are implicit.
+          'field' => $entity_info['entity keys']['bundle'],
+          'value' => $this->options['bundle_types'],
+        ),
+      );
+    }
+
+    if (!empty($def['join_handler']) && class_exists($def['join_handler'])) {
+      $join = new $def['join_handler'];
+    }
+    else {
+      $join = new views_join();
+    }
+
+    $join->definition = $def;
+    $join->construct();
+    $join->adjusted = TRUE;
+
+    // Use a short alias for this.
+    $alias = $def['table'] . '_' . $this->table;
+    $this->alias = $this->query->add_relationship($alias, $join, $this->definition['base'], $this->relationship);
+  }
+}

--- a/views/plugins/entity_plus_views_plugin_row_entity_view.inc
+++ b/views/plugins/entity_plus_views_plugin_row_entity_view.inc
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @file
+ * Row style plugin for displaying the results as entities.
+ */
+
+/**
+ * Plugin class for displaying Views results with entity_view.
+ */
+class entity_plus_views_plugin_row_entity_view extends views_plugin_row {
+
+  protected $entity_type, $entities;
+
+  public function init(&$view, &$display, $options = NULL) {
+    parent::init($view, $display, $options);
+
+    // Initialize the entity-type used.
+    $table_data = views_fetch_data($this->view->base_table);
+    $this->entity_type = $table_data['table']['entity type'];
+    // Set base table and field information as used by views_plugin_row to
+    // select the entity id if used with default query class.
+    $info = entity_get_info($this->entity_type);
+    if (!empty($info['base table']) && $info['base table'] == $this->view->base_table) {
+      $this->base_table = $info['base table'];
+      $this->base_field = $info['entity keys']['id'];
+    }
+  }
+
+  public function option_definition() {
+    $options = parent::option_definition();
+    $options['view_mode'] = array('default' => 'full');
+    return $options;
+  }
+
+  public function options_form(&$form, &$form_state) {
+    parent::options_form($form, $form_state);
+
+    $entity_info = entity_get_info($this->entity_type);
+    $options = array();
+    if (!empty($entity_info['view modes'])) {
+      foreach ($entity_info['view modes'] as $mode => $settings) {
+        $options[$mode] = $settings['label'];
+      }
+    }
+
+    if (count($options) > 1) {
+      $form['view_mode'] = array(
+        '#type' => 'select',
+        '#options' => $options,
+        '#title' => t('View mode'),
+        '#default_value' => $this->options['view_mode'],
+      );
+    }
+    else {
+      $form['view_mode_info'] = array(
+        '#type' => 'item',
+        '#title' => t('View mode'),
+        '#description' => t('Only one view mode is available for this entity type.'),
+        '#markup' => $options ? current($options) : t('Default'),
+      );
+      $form['view_mode'] = array(
+        '#type' => 'value',
+        '#value' => $options ? key($options) : 'default',
+      );
+    }
+    return $form;
+  }
+
+  public function pre_render($values) {
+    if (!empty($values)) {
+      list($this->entity_type, $this->entities) = $this->view->query->get_result_entities($values, !empty($this->relationship) ? $this->relationship : NULL, isset($this->field_alias) ? $this->field_alias : NULL);
+    }
+    // Render the entities.
+    if ($this->entities) {
+      $render = entity_view($this->entity_type, $this->entities, $this->options['view_mode']);
+      // Remove the first level of the render array.
+      $this->rendered_content = reset($render);
+    }
+  }
+
+  /**
+   * Overridden to return the entity object.
+   */
+  function get_value($values, $field = NULL) {
+    return isset($this->entities[$this->view->row_index]) ? $this->entities[$this->view->row_index] : FALSE;
+  }
+
+  public function render($values) {
+    if ($entity = $this->get_value($values)) {
+      // Add the view object as views_plugin_row_node_view::render() would.
+      // Otherwise the views theme suggestions won't work properly.
+      $entity->view = $this->view;
+      $render = $this->rendered_content[entity_id($this->entity_type, $entity)];
+      return backdrop_render($render);
+    }
+  }
+}


### PR DESCRIPTION
Supports Views integration for (exportable) entities if the following cases exist:

* hook_entity_info() specifies a 'views controller class' key.
* hook_entity_info() specifies a 'module' key, and the module does not
* implement hook_views_data().

This code was re-factored from it's original source found here: https://www.drupal.org/project/entity/releases/7.x-1.9

Fixes this issue: https://github.com/backdrop-contrib/search_api/issues/3