### PR TITLE
Added property_type for email field

### DIFF
--- a/includes/entity_plus.property.inc
+++ b/includes/entity_plus.property.inc
@@ -201,6 +201,9 @@ function entity_plus_field_info_alter(&$field_info) {
     $field_info['image']['property_callbacks'][] = 'entity_plus_metadata_field_file_callback';
     $field_info['image']['property_callbacks'][] = 'entity_plus_metadata_field_image_callback';
   }
+  if (module_exists('email')) {
+    $field_info['email']['property_type'] = 'text';
+  }
 }
 
 /**


### PR DESCRIPTION
Adds property_type for email field, which is now in core. This allows for use of entity_metadata_wrapper with email fields. See issue #14  