### PR TITLE
Use entity_load instead of entity_load_single

### DIFF
--- a/views/handlers/entity_plus_views_handler_area_entity.inc
+++ b/views/handlers/entity_plus_views_handler_area_entity.inc
@@ -109,7 +109,7 @@ class entity_plus_views_handler_area_entity extends views_handler_area {
     // Replace argument tokens in entity id.
     $entity_id = strtr($entity_id, $tokens);
     if (!empty($entity_type) && !empty($entity_id) && !empty($view_mode)) {
-      $entity = entity_load_single($entity_type, $entity_id);
+      $entity = entity_load($entity_type, $entity_id);
       if (!empty($this->options['bypass_access']) || entity_access('view', $entity_type, $entity)) {
         $render = entity_plus_view($entity_type, array($entity), $view_mode);
         $render_entity = reset($render);

--- a/views/handlers/entity_plus_views_handler_field_entity.inc
+++ b/views/handlers/entity_plus_views_handler_field_entity.inc
@@ -150,8 +150,8 @@ class entity_plus_views_handler_field_entity extends views_handler_field {
   /**
    * Render a value as a link to the entity if applicable.
    *
-   * @param $value
-   *   The value to render.
+   * @param $entity
+   *   The the ID of the entity.
    * @param $values
    *   The values for the current row retrieved from the Views query, as an
    *   object.
@@ -159,7 +159,7 @@ class entity_plus_views_handler_field_entity extends views_handler_field {
   public function render_entity_link($entity, $values) {
     $type = $this->field_entity_type;
     if (!is_object($entity) && isset($entity) && $entity !== FALSE) {
-      $entity = entity_load_single($type, $entity);
+      $entity = entity_load($type, $entity);
     }
     if (!$entity) {
       return '';
@@ -180,7 +180,7 @@ class entity_plus_views_handler_field_entity extends views_handler_field {
   public function render_single_value($entity, $values) {
     $type = $this->field_entity_type;
     if (!is_object($entity) && isset($entity) && $entity !== FALSE) {
-      $entity = entity_load_single($type, $entity);
+      $entity = entity_load($type, $entity);
     }
     // Make sure the entity exists and access is either given or bypassed.
     if (!$entity || !(!empty($this->options['bypass_access']) || entity_access('view', $type, $entity))) {


### PR DESCRIPTION
Refers to issue #55. The function `entity_load_single` has been removed from Backdrop and replaced by `entity_load`.