### PR TITLE
Fixes option list test that failed because of user roles

### DIFF
--- a/tests/entity_plus.test
+++ b/tests/entity_plus.test
@@ -237,8 +237,8 @@ class EntityPlusMetadataTestCase extends EntityPlusHelperTestCase {
     user_save($user, array('roles' => array()));
     $wrapper->author = $user->uid;
     $this->assertEqual($wrapper->label(), $node->title, 'Entity label returned.');
-    $this->assertEqual($wrapper->author->roles[0]->label(), t('authenticated user'), 'Label from options list returned');
-    $this->assertEqual($wrapper->author->roles->label(), t('authenticated user'), 'Label for a list from options list returned');
+    $this->assertEqual($wrapper->author->roles[0]->label(), t('Authenticated'), 'Label from options list returned');
+    $this->assertEqual($wrapper->author->roles->label(), t('Authenticated'), 'Label for a list from options list returned');
   }
 
   /**
@@ -424,9 +424,10 @@ class EntityPlusMetadataTestCase extends EntityPlusHelperTestCase {
 
     $results = entity_plus_property_query('node', $this->field_name, array('foo', 'bar'));
     $this->assertEqual($results, array($node->nid), 'Queried nodes with a list of possible values.');
-
-    $results = entity_plus_property_query('node', 'author', $GLOBALS['user']);
-    $this->assertEqual($results, array($node->nid), 'Queried nodes with a given auhtor.');
+ 
+    $results = entity_plus_property_query('node', 'author', $GLOBALS['user']->uid);
+    // Backdrop provides 2 nodes with uid == 1 on clean install, meaning that assertEqual will not work
+    $this->assertTrue(in_array($node->nid, $results), 'Queried nodes with a given author.');
 
     // Create another test node and try querying for tags.
     $vocab = $this->createVocabulary();


### PR DESCRIPTION
Fixes #88.

IMPORTANT: in order for these fixes to work, it's important to merge PRs #85 and #83 