### PR TITLE
Clean up vocabulary and term wrapper

### DIFF
--- a/entity_plus.module
+++ b/entity_plus.module
@@ -316,16 +316,6 @@ function _entity_plus_info_add_metadata(&$entity_plus_info) {
     $entity_plus_info['taxonomy_term']['view callback'] = 'entity_plus_metadata_view_single';
     $entity_plus_info['taxonomy_term']['form callback'] = 'entity_plus_metadata_form_taxonomy_term';
 
-    if (isset($entity_plus_info['taxonomy_vocabulary'])) {
-      $entity_plus_info['taxonomy_vocabulary']['plural label'] = t('Taxonomy vocabularies');
-      $entity_plus_info['taxonomy_vocabulary']['description'] = t('Vocabularies contain related taxonomy terms, which are used for classifying content.');
-      $entity_plus_info['taxonomy_vocabulary']['access callback'] = 'entity_plus_metadata_taxonomy_access';
-      $entity_plus_info['taxonomy_vocabulary']['creation callback'] = 'entity_plus_metadata_create_object';
-      $entity_plus_info['taxonomy_vocabulary']['save callback'] = 'taxonomy_vocabulary_save';
-      $entity_plus_info['taxonomy_vocabulary']['deletion callback'] = 'taxonomy_vocabulary_delete';
-      $entity_plus_info['taxonomy_vocabulary']['form callback'] = 'entity_plus_metadata_form_taxonomy_vocabulary';
-      $entity_plus_info['taxonomy_vocabulary']['token type'] = 'vocabulary';
-    }
     // Token type mapping.
     $entity_plus_info['taxonomy_term']['token type'] = 'term';
   }

--- a/modules/callbacks.inc
+++ b/modules/callbacks.inc
@@ -304,15 +304,28 @@ function entity_plus_metadata_taxonomy_term_get_properties($term, array $options
       if (isset($term->parent[0]) && !is_array(isset($term->parent[0]))) {
         return $term->parent;
       }
-      return array_keys(taxonomy_get_parents($term->tid));
+      return array_keys(taxonomy_term_load_parents($term->tid));
 
     case 'parents_all':
       // We have to return an array of ids.
       $tids = array();
-      foreach (taxonomy_get_parents_all($term->tid) as $parent) {
+      foreach (taxonomy_term_load_parents_all($term->tid) as $parent) {
         $tids[] = $parent->tid;
       }
       return $tids;
+      
+    case 'vocabulary':
+      return taxonomy_vocabulary_load($term->vocabulary);
+  }
+}
+
+/** 
+ * Callback for getting raw term properties
+ */
+function entity_plus_metadata_taxonomy_term_get_raw_properties($term, array $options, $name) {
+  switch ($name) {
+    case 'vocabulary':
+      return $term->vocabulary;
   }
 }
 
@@ -324,11 +337,8 @@ function entity_plus_metadata_taxonomy_term_get_properties($term, array $options
 function entity_plus_metadata_taxonomy_term_setter($term, $name, $value) {
   switch ($name) {
     case 'vocabulary':
-      // Make sure to update the taxonomy bundle key, so load the vocabulary.
-      // Support both, loading by name or ID.
-      $vocabulary = is_numeric($value) ? taxonomy_vocabulary_load($value) : taxonomy_vocabulary_machine_name_load($value);
-      $term->vocabulary_machine_name = $vocabulary->machine_name;
-      return $term->vid = $vocabulary->vid;
+      $term->vocabulary = $value->machine_name;
+      return $term->vocabulary;
     case 'parent':
       return $term->parent = $value;
   }
@@ -341,8 +351,8 @@ function entity_plus_metadata_taxonomy_term_setter($term, $name, $value) {
 function entity_plus_metadata_taxonomy_vocabulary_get_properties($vocabulary, array $options, $name) {
   switch ($name) {
     case 'term_count':
-      $sql = "SELECT COUNT (1) FROM {taxonomy_term_data} td WHERE td.vid = :vid";
-      return db_query($sql, array(':vid' => $vocabulary->vid))->fetchField();
+      $sql = "SELECT COUNT (1) FROM {taxonomy_term_data} td WHERE td.vocabulary = :vocabulary";
+      return db_query($sql, array(':vocabulary' => $vocabulary->machine_name))->fetchField();
   }
 }
 
@@ -798,9 +808,6 @@ function entity_plus_metadata_comment_properties_access($op, $property, $entity 
  * Access callback for the taxonomy entities.
  */
 function entity_plus_metadata_taxonomy_access($op, $entity = NULL, $account = NULL, $entity_plus_type = NULL) {
-  if ($entity_plus_type == 'taxonomy_vocabulary') {
-    return user_access('administer taxonomy', $account);
-  }
   if (isset($entity) && $op == 'update' && !isset($account) && user_access("edit terms in {$entity->vocabulary}")) {
     return TRUE;
   }

--- a/modules/taxonomy.info.inc
+++ b/modules/taxonomy.info.inc
@@ -62,9 +62,38 @@ function entity_plus_metadata_taxonomy_entity_property_info() {
     'label' => t("Vocabulary"),
     'description' => t("The vocabulary the taxonomy term belongs to."),
     'setter callback' => 'entity_plus_metadata_taxonomy_term_setter',
-    'type' => 'taxonomy_vocabulary',
-    'required' => TRUE,
-    'schema field' => 'vid',
+    'getter callback' => 'entity_plus_metadata_taxonomy_term_get_properties',
+    'raw getter callback' => 'entity_plus_property_verbatim_get',
+    'type' => 'struct',
+    
+    'property info' => array(
+      'name' => array(
+        'label' => t("Name"),
+        'description' => t("The name of the taxonomy vocabulary."),
+        'setter callback' => 'entity_plus_property_verbatim_set',
+        'required' => TRUE,
+      ),
+      'machine_name' => array(
+        'label' => t("Machine name"),
+        'type' => 'token',
+        'description' => t("The machine name of the taxonomy vocabulary."),
+        'setter callback' => 'entity_plus_property_verbatim_set',
+        'required' => TRUE,
+      ),
+      'description' => array(
+        'label' => t("Description"),
+        'description' => t("The optional description of the taxonomy vocabulary."),
+        'setter callback' => 'entity_plus_property_verbatim_set',
+        'sanitize' => 'filter_xss',
+      ),
+      'term_count' => array(
+        'label' => t("Term count"),
+        'type' => 'integer',
+        'description' => t("The number of terms belonging to the taxonomy vocabulary."),
+        'getter callback' => 'entity_plus_metadata_taxonomy_vocabulary_get_properties',
+        'computed' => TRUE,
+      ),
+    ),
   );
   $properties['parent'] = array(
     'label' => t("Parent terms"),
@@ -81,44 +110,5 @@ function entity_plus_metadata_taxonomy_entity_property_info() {
     'computed' => TRUE,
   );
 
-  // Add meta-data about the basic vocabulary properties.
-  $properties = &$info['taxonomy_vocabulary']['properties'];
-
-  // Taxonomy vocabulary related variables.
-  $properties['vid'] = array(
-    'label' => t("Vocabulary ID"),
-    'description' => t("The unique ID of the taxonomy vocabulary."),
-    'type' => 'integer',
-    'schema field' => 'vid',
-  );
-  $properties['name'] = array(
-    'label' => t("Name"),
-    'description' => t("The name of the taxonomy vocabulary."),
-    'setter callback' => 'entity_plus_property_verbatim_set',
-    'required' => TRUE,
-    'schema field' => 'name',
-  );
-  $properties['machine_name'] = array(
-    'label' => t("Machine name"),
-    'type' => 'token',
-    'description' => t("The machine name of the taxonomy vocabulary."),
-    'setter callback' => 'entity_plus_property_verbatim_set',
-    'required' => TRUE,
-    'schema field' => 'machine_name',
-  );
-  $properties['description'] = array(
-    'label' => t("Description"),
-    'description' => t("The optional description of the taxonomy vocabulary."),
-    'setter callback' => 'entity_plus_property_verbatim_set',
-    'sanitize' => 'filter_xss',
-    'schema field' => 'description',
-  );
-  $properties['term_count'] = array(
-    'label' => t("Term count"),
-    'type' => 'integer',
-    'description' => t("The number of terms belonging to the taxonomy vocabulary."),
-    'getter callback' => 'entity_plus_metadata_taxonomy_vocabulary_get_properties',
-    'computed' => TRUE,
-  );
   return $info;
 }


### PR DESCRIPTION
Fixes #96

As vocabularies are no longer entities in Backdrop, I had to modify the metadata wrapper property definitions for terms and vocabulary. I had to change the vocabulary property definition within the taxonomy definitions to 'struct' in order to be able to access the vocabulary property values.  Unfortunately, because vocabularies are no longer entities, it's no longer possible to modify or save vocabularies through metadata wrappers. However the getters are working fine. 

It may be possible to create a new metadata wrapper class for vocabularies that would allow for setting and saving - but that's a task for another day.  